### PR TITLE
Add 5 new example notebooks covering GPs, batching, duals, robust opt, and more

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -199,6 +199,50 @@ Supply chain network flow optimization.
 Optimizing mechanical stiffness parameters.
 :::
 
+:::{grid-item-card} GP Circuit Sizing
+:link: https://colab.research.google.com/github/cvxpy/cvxpylayers/blob/master/examples/torch/gp_circuit_sizing.ipynb
+:link-type: url
+
+Geometric program for transistor sizing with `gp=True`. Sensitivity analysis of delay vs. area/power budgets.
+:::
+
+::::
+
+---
+
+## Optimization Techniques
+
+::::{grid} 1 1 2 2
+:gutter: 3
+
+:::{grid-item-card} Batched Portfolio with Duals
+:link: https://colab.research.google.com/github/cvxpy/cvxpylayers/blob/master/examples/torch/batched_portfolio.ipynb
+:link-type: url
+
+Batched solving, parameter broadcasting, and dual variable extraction for portfolio optimization.
+:::
+
+:::{grid-item-card} Robust Optimization
+:link: https://colab.research.google.com/github/cvxpy/cvxpylayers/blob/master/examples/torch/robust_optimization.ipynb
+:link-type: url
+
+Learn the right amount of robustness from data. Worst-case design under uncertainty.
+:::
+
+:::{grid-item-card} Predict-then-Optimize
+:link: https://colab.research.google.com/github/cvxpy/cvxpylayers/blob/master/examples/torch/predict_then_optimize.ipynb
+:link-type: url
+
+Neural net + CvxpyLayer end-to-end pipeline. Decision-focused learning vs. two-stage training.
+:::
+
+:::{grid-item-card} Convex Regression
+:link: https://colab.research.google.com/github/cvxpy/cvxpylayers/blob/master/examples/torch/convex_regression.ipynb
+:link-type: url
+
+Fit a convex piecewise-linear function (max-of-affines) to data via SGD.
+:::
+
 ::::
 
 ---

--- a/examples/jax/jax_example.py
+++ b/examples/jax/jax_example.py
@@ -12,7 +12,7 @@ objective = cp.Minimize(0.5 * cp.pnorm(A @ x - b, p=1))
 problem = cp.Problem(objective, constraints)
 assert problem.is_dpp()
 
-cvxpylayer = CvxpyLayer(problem, parameters=[A, b], variables=[x], solver=cp.CUCLARABEL)
+cvxpylayer = CvxpyLayer(problem, parameters=[A, b], variables=[x])
 key = jax.random.PRNGKey(0)
 key, k1, k2 = jax.random.split(key, 3)
 A_jax = jax.random.normal(k1, shape=(m, n))

--- a/examples/torch/batched_portfolio.ipynb
+++ b/examples/torch/batched_portfolio.ipynb
@@ -1,0 +1,212 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Batched Portfolio Optimization with Dual Variables\n",
+    "\n",
+    "This notebook demonstrates two key CVXPYlayers features:\n",
+    "\n",
+    "1. **Batched solving** — solve many problem instances simultaneously by passing batched parameters\n",
+    "2. **Dual variable extraction** — retrieve shadow prices from constraints\n",
+    "\n",
+    "**Problem**: Markowitz mean-variance portfolio optimization with a parametric risk budget.\n",
+    "\n",
+    "$$\\max_{w} \\; \\mu^T w \\quad \\text{s.t.} \\; w^T \\Sigma w \\leq \\sigma_{\\max}^2, \\; \\mathbf{1}^T w = 1, \\; w \\geq 0$$\n",
+    "\n",
+    "**Key API**:\n",
+    "- Batched parameters: pass tensors with shape `(batch_size, ...)`\n",
+    "- Broadcasting: mix batched and unbatched parameters\n",
+    "- `constraint.dual_variables[0]` — include dual variables in the output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cvxpy as cp\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import torch\n",
+    "\n",
+    "from cvxpylayers.torch import CvxpyLayer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define the Portfolio Problem\n",
+    "\n",
+    "We include the risk constraint's dual variable in the output. The dual value represents the *shadow price* of risk — how much additional expected return we'd get per unit relaxation of the risk constraint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_assets = 5\n",
+    "\n",
+    "w = cp.Variable(n_assets, name=\"weights\")\n",
+    "mu = cp.Parameter(n_assets, name=\"expected_returns\")\n",
+    "sigma_max = cp.Parameter(pos=True, name=\"risk_budget\")\n",
+    "\n",
+    "# Generate a fixed covariance matrix\n",
+    "np.random.seed(42)\n",
+    "F = np.random.randn(n_assets, n_assets) * 0.1\n",
+    "Sigma = F.T @ F + 0.05 * np.eye(n_assets)\n",
+    "Sigma_sqrt = np.linalg.cholesky(Sigma)\n",
+    "\n",
+    "# Risk constraint: ||Sigma^{1/2} w||_2 <= sigma_max (SOC form)\n",
+    "risk_constraint = cp.norm(Sigma_sqrt.T @ w, 2) <= sigma_max\n",
+    "\n",
+    "constraints = [\n",
+    "    risk_constraint,\n",
+    "    cp.sum(w) == 1,\n",
+    "    w >= 0,\n",
+    "]\n",
+    "\n",
+    "objective = cp.Maximize(mu @ w)\n",
+    "problem = cp.Problem(objective, constraints)\n",
+    "assert problem.is_dpp()\n",
+    "\n",
+    "# Include the dual variable for the risk constraint\n",
+    "risk_dual = risk_constraint.dual_variables[0]\n",
+    "layer = CvxpyLayer(\n",
+    "    problem,\n",
+    "    parameters=[mu, sigma_max],\n",
+    "    variables=[w, risk_dual],\n",
+    ")\n",
+    "print(f\"Layer outputs: optimal weights (dim {n_assets}) + risk dual (scalar)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Unbatched Solve\n",
+    "\n",
+    "First, solve a single instance to verify correctness."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mu_tch = torch.tensor([0.12, 0.10, 0.07, 0.03, 0.02], dtype=torch.float64)\n",
+    "sigma_max_tch = torch.tensor(0.15, dtype=torch.float64)\n",
+    "\n",
+    "w_opt, dual_opt = layer(mu_tch, sigma_max_tch)\n",
+    "\n",
+    "print(\"Optimal weights:\", w_opt.detach().numpy().round(4))\n",
+    "print(f\"Portfolio return: {(mu_tch @ w_opt).item():.4f}\")\n",
+    "print(f\"Portfolio risk:   {torch.norm(torch.tensor(Sigma_sqrt.T) @ w_opt).item():.4f}\")\n",
+    "print(f\"Risk budget:      {sigma_max_tch.item():.4f}\")\n",
+    "print(f\"Risk dual value:  {dual_opt.detach().numpy().round(4)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Batched Solve: Multiple Return Forecasts\n",
+    "\n",
+    "Pass a batch of expected return vectors. The first dimension is the batch dimension."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "batch_size = 8\ntorch.manual_seed(0)\n\n# Batch of return forecasts: shape (batch_size, n_assets)\n# Use abs to ensure positive expected returns (realistic for financial assets)\nmu_batch = torch.abs(torch.randn(batch_size, n_assets, dtype=torch.float64) * 0.03 + 0.06)\n\n# Unbatched risk budget — automatically broadcast across the batch\nsigma_max_tch = torch.tensor(0.20, dtype=torch.float64)\n\nw_batch, dual_batch = layer(mu_batch, sigma_max_tch)\n\nprint(f\"Input  mu shape:       {mu_batch.shape}\")\nprint(f\"Output weights shape:  {w_batch.shape}\")\nprint(f\"Output dual shape:     {dual_batch.shape}\")\nprint()\nprint(\"Weights sum to 1 for each batch element:\")\nprint(w_batch.sum(dim=1).detach().numpy().round(6))"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Broadcasting: Sweep Risk Budget\n",
+    "\n",
+    "Use a batched `sigma_max` with an unbatched `mu` to trace the efficient frontier. CVXPYlayers broadcasts the unbatched parameter across the batch automatically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "mu_fixed = torch.tensor([0.12, 0.10, 0.07, 0.03, 0.02], dtype=torch.float64)\n\n# Sweep risk budgets above the minimum feasible risk (~0.148)\nn_points = 40\nsigma_values = torch.linspace(0.15, 0.45, n_points, dtype=torch.float64)\n\nreturns = []\nrisks = []\nduals = []\n\nfor sig in sigma_values:\n    w_sol, d_sol = layer(mu_fixed, sig)\n    ret = (mu_fixed @ w_sol).item()\n    risk = torch.norm(torch.tensor(Sigma_sqrt.T, dtype=torch.float64) @ w_sol).item()\n    returns.append(ret)\n    risks.append(risk)\n    duals.append(d_sol.detach().numpy().flatten()[0])"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(11, 4))\n",
+    "\n",
+    "ax1.plot(risks, returns, 'b-o', markersize=3, linewidth=2)\n",
+    "ax1.set_xlabel('Portfolio Risk (std dev)')\n",
+    "ax1.set_ylabel('Expected Return')\n",
+    "ax1.set_title('Efficient Frontier')\n",
+    "ax1.grid(True, alpha=0.3)\n",
+    "\n",
+    "ax2.plot(sigma_values.numpy(), duals, 'r-o', markersize=3, linewidth=2)\n",
+    "ax2.set_xlabel('Risk Budget (sigma_max)')\n",
+    "ax2.set_ylabel('Dual Value (Shadow Price of Risk)')\n",
+    "ax2.set_title('Risk Constraint Dual')\n",
+    "ax2.grid(True, alpha=0.3)\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "print(\"The dual value decreases as the risk budget relaxes (constraint becomes slack).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Verify: Dual Values Match Gradients\n",
+    "\n",
+    "The dual value of the risk constraint should equal the gradient of the optimal return with respect to the risk budget (by the envelope theorem)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Compute gradient d(return)/d(sigma_max) and compare to dual\n",
+    "sigma_test = torch.tensor(0.15, dtype=torch.float64, requires_grad=True)\n",
+    "w_sol, dual_sol = layer(mu_fixed, sigma_test)\n",
+    "opt_return = mu_fixed @ w_sol\n",
+    "opt_return.backward()\n",
+    "\n",
+    "print(f\"Gradient d(return)/d(sigma_max): {sigma_test.grad.item():.6f}\")\n",
+    "print(f\"Dual value of risk constraint:   {dual_sol.detach().numpy().flatten()[0]:.6f}\")\n",
+    "print(f\"These should be close (envelope theorem).\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/torch/convex_regression.ipynb
+++ b/examples/torch/convex_regression.ipynb
@@ -1,0 +1,262 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Convex Regression: Learning Convex Functions from Data\n",
+    "\n",
+    "This notebook demonstrates **convex regression** — learning a convex function that best fits scattered data, using CVXPYlayers to enforce convexity constraints.\n",
+    "\n",
+    "**Model**: We represent the convex function as a max-of-affines:\n",
+    "\n",
+    "$$f_\\theta(x) = \\max_j \\; (a_j x + b_j)$$\n",
+    "\n",
+    "where $\\theta = \\{a_j, b_j\\}_{j=1}^K$ are learnable PyTorch parameters. Since the pointwise max of affine functions is always convex, this model is *convex by construction*.\n",
+    "\n",
+    "**Approach**: We evaluate $f_\\theta$ directly in PyTorch (using `torch.max`), and use a CvxpyLayer to solve a **convex projection** problem — projecting noisy data onto the epigraph of $f_\\theta$ to get denoised predictions.\n",
+    "\n",
+    "**Training**: Learn $\\theta$ via SGD to minimize prediction error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cvxpy as cp\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "\n",
+    "from cvxpylayers.torch import CvxpyLayer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate Data from a Convex Function\n",
+    "\n",
+    "We sample data from a known convex function $g(x) = x^2/4 + |x|$ with added noise."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.random.seed(42)\n",
+    "torch.manual_seed(42)\n",
+    "\n",
+    "n_data = 150\n",
+    "\n",
+    "X_np = np.random.uniform(-3, 3, size=(n_data, 1))\n",
+    "\n",
+    "def true_convex(x):\n",
+    "    return 0.25 * x[:, 0] ** 2 + np.abs(x[:, 0])\n",
+    "\n",
+    "Y_np = true_convex(X_np) + 0.3 * np.random.randn(n_data)\n",
+    "\n",
+    "X_data = torch.tensor(X_np, dtype=torch.float64)\n",
+    "Y_data = torch.tensor(Y_np, dtype=torch.float64)\n",
+    "\n",
+    "print(f\"{n_data} data points generated.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Max-of-Affines Evaluation (PyTorch)\n",
+    "\n",
+    "The function $f_\\theta(x) = \\max_j (a_j x + b_j)$ is differentiable almost everywhere and can be computed directly in PyTorch. The slopes $a_j$ and intercepts $b_j$ are learnable parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "K = 8  # number of affine pieces\n",
+    "\n",
+    "# Learnable parameters\n",
+    "a_tch = nn.Parameter(torch.randn(K, 1, dtype=torch.float64) * 0.5)\n",
+    "b_tch = nn.Parameter(torch.randn(K, dtype=torch.float64) * 0.5)\n",
+    "\n",
+    "def max_of_affines(x, a, b):\n",
+    "    \"\"\"Evaluate f(x) = max_j (a_j^T x + b_j) for a batch of x.\n",
+    "    \n",
+    "    Args:\n",
+    "        x: (batch, input_dim)\n",
+    "        a: (K, input_dim) slopes\n",
+    "        b: (K,) intercepts\n",
+    "    Returns:\n",
+    "        (batch,) function values\n",
+    "    \"\"\"\n",
+    "    # (batch, K) = (batch, input_dim) @ (input_dim, K) + (K,)\n",
+    "    vals = x @ a.T + b.unsqueeze(0)\n",
+    "    return vals.max(dim=1).values\n",
+    "\n",
+    "print(f\"Max-of-{K}-affines model with {2*K} parameters.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## CvxpyLayer: Convex Projection\n",
+    "\n",
+    "Given a noisy observation $y$ and a convex function $f_\\theta$, we can *project* $y$ onto the epigraph of $f_\\theta$ at point $x$ by solving:\n",
+    "\n",
+    "$$\\min_z \\; (z - y)^2 \\quad \\text{s.t.} \\; z \\geq c$$\n",
+    "\n",
+    "where $c$ is the convex function value $f_\\theta(x)$. This is a parametric QP with parameter $c$ (the function value) and $y$ (the target). The CvxpyLayer allows gradients to flow back through this projection."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "z = cp.Variable(name=\"z\")\n",
+    "c_param = cp.Parameter(name=\"lower_bound\")\n",
+    "y_param = cp.Parameter(name=\"target\")\n",
+    "\n",
+    "# Project y onto [c, inf) — closest point to y that's >= c\n",
+    "objective = cp.Minimize(cp.square(z - y_param))\n",
+    "constraints = [z >= c_param]\n",
+    "proj_problem = cp.Problem(objective, constraints)\n",
+    "assert proj_problem.is_dpp()\n",
+    "\n",
+    "proj_layer = CvxpyLayer(proj_problem, parameters=[c_param, y_param], variables=[z])\n",
+    "print(\"Projection layer created.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Training Loop\n",
+    "\n",
+    "We train the max-of-affines parameters to minimize MSE. The CvxpyLayer projection clips predictions to be at least as large as the convex function value, acting as a convexity-aware regularizer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optimizer = torch.optim.Adam([a_tch, b_tch], lr=0.05)\n",
+    "losses = []\n",
+    "\n",
+    "n_epochs = 300\n",
+    "batch_size = 32\n",
+    "\n",
+    "for epoch in range(n_epochs):\n",
+    "    idx = torch.randperm(n_data)[:batch_size]\n",
+    "    X_batch = X_data[idx]\n",
+    "    Y_batch = Y_data[idx]\n",
+    "\n",
+    "    optimizer.zero_grad()\n",
+    "    \n",
+    "    # Evaluate max-of-affines\n",
+    "    f_vals = max_of_affines(X_batch, a_tch, b_tch)\n",
+    "    \n",
+    "    # Project targets through CvxpyLayer\n",
+    "    projected = []\n",
+    "    for i in range(batch_size):\n",
+    "        (z_val,) = proj_layer(f_vals[i], Y_batch[i])\n",
+    "        projected.append(z_val)\n",
+    "    projected = torch.stack(projected).squeeze()\n",
+    "    \n",
+    "    loss = torch.mean((projected - Y_batch) ** 2)\n",
+    "    loss.backward()\n",
+    "    optimizer.step()\n",
+    "    losses.append(loss.item())\n",
+    "\n",
+    "    if (epoch + 1) % 75 == 0:\n",
+    "        print(f\"Epoch {epoch+1:4d} | Loss: {loss.item():.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualize the Learned Convex Function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Evaluate on a dense grid\n",
+    "x_grid = torch.linspace(-3.5, 3.5, 200, dtype=torch.float64).unsqueeze(1)\n",
+    "\n",
+    "with torch.no_grad():\n",
+    "    y_learned = max_of_affines(x_grid, a_tch, b_tch).numpy()\n",
+    "\n",
+    "y_true = true_convex(x_grid.numpy())\n",
+    "\n",
+    "# Individual affine pieces\n",
+    "a_np = a_tch.detach().numpy()\n",
+    "b_np = b_tch.detach().numpy()\n",
+    "x_plot = x_grid.numpy().flatten()\n",
+    "\n",
+    "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 5))\n",
+    "\n",
+    "# Left: fit vs true\n",
+    "ax1.scatter(X_np, Y_np, alpha=0.3, s=15, c='gray', label='Data')\n",
+    "ax1.plot(x_plot, y_true, 'b--', linewidth=2, label='True function')\n",
+    "ax1.plot(x_plot, y_learned, 'r-', linewidth=2, label='Learned (max-of-affines)')\n",
+    "for j in range(K):\n",
+    "    y_affine = a_np[j, 0] * x_plot + b_np[j]\n",
+    "    ax1.plot(x_plot, y_affine, '--', alpha=0.2, color='orange', linewidth=0.8)\n",
+    "ax1.set_xlabel('x')\n",
+    "ax1.set_ylabel('y')\n",
+    "ax1.set_title('Convex Regression Fit')\n",
+    "ax1.legend()\n",
+    "ax1.set_ylim(-1, 7)\n",
+    "ax1.grid(True, alpha=0.3)\n",
+    "\n",
+    "# Right: training loss\n",
+    "ax2.plot(losses, 'g-', alpha=0.7)\n",
+    "ax2.set_xlabel('Epoch')\n",
+    "ax2.set_ylabel('MSE Loss')\n",
+    "ax2.set_title('Training Loss')\n",
+    "ax2.grid(True, alpha=0.3)\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "# Final evaluation on all data\n",
+    "with torch.no_grad():\n",
+    "    f_all = max_of_affines(X_data, a_tch, b_tch)\n",
+    "final_mse = torch.mean((f_all - Y_data) ** 2).item()\n",
+    "print(f\"Final MSE on all data: {final_mse:.4f}\")\n",
+    "print(f\"Learned {K} affine pieces with slopes: {a_np.flatten().round(3)}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/torch/gp_circuit_sizing.ipynb
+++ b/examples/torch/gp_circuit_sizing.ipynb
@@ -1,0 +1,202 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Geometric Program: Circuit Sizing\n",
+    "\n",
+    "This notebook demonstrates how to use CVXPYlayers with **geometric programs** (GPs).\n",
+    "\n",
+    "Geometric programs are a class of optimization problems where the objective and constraints are formed from *posynomials* — sums of monomials with positive coefficients. CVXPY supports GPs via `cp.Variable(pos=True)` and the `gp=True` flag.\n",
+    "\n",
+    "**Problem**: We size transistor widths to minimize propagation delay subject to area and power budgets. This is a classic GP from Boyd et al. (2007).\n",
+    "\n",
+    "**Key API**:\n",
+    "- `cp.Variable(pos=True)` — positive variables for GP\n",
+    "- `problem.is_dgp(dpp=True)` — verify DGP-DPP compliance\n",
+    "- `CvxpyLayer(..., gp=True)` — enable GP mode"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cvxpy as cp\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import torch\n",
+    "\n",
+    "from cvxpylayers.torch import CvxpyLayer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define the Geometric Program\n",
+    "\n",
+    "We model a simple 3-stage digital circuit. Each stage $i$ has a transistor width $w_i > 0$.\n",
+    "\n",
+    "- **Delay** of each stage is inversely proportional to its width: $d_i = \\alpha_i / w_i$\n",
+    "- **Area** of each stage is proportional to its width: total area $= \\sum_i w_i$\n",
+    "- **Power** scales as width times switching frequency: total power $= \\sum_i \\beta_i w_i$\n",
+    "\n",
+    "The total delay is $\\sum_i d_i = \\sum_i \\alpha_i / w_i$, which we minimize subject to parametric area and power budgets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_stages = 3\n",
+    "\n",
+    "# Positive variables (required for GP)\n",
+    "w = cp.Variable(n_stages, pos=True, name=\"widths\")\n",
+    "\n",
+    "# Fixed coefficients\n",
+    "alpha = np.array([1.0, 1.5, 0.8])  # delay coefficients\n",
+    "beta = np.array([0.5, 0.8, 0.6])   # power coefficients\n",
+    "\n",
+    "# Parametric budgets\n",
+    "A_max = cp.Parameter(pos=True, name=\"area_budget\")\n",
+    "P_max = cp.Parameter(pos=True, name=\"power_budget\")\n",
+    "\n",
+    "# Objective: minimize total delay (sum of alpha_i / w_i)\n",
+    "delay = sum(alpha[i] * cp.inv_pos(w[i]) for i in range(n_stages))\n",
+    "objective = cp.Minimize(delay)\n",
+    "\n",
+    "# Constraints\n",
+    "constraints = [\n",
+    "    cp.sum(w) <= A_max,                        # area budget\n",
+    "    beta @ w <= P_max,                          # power budget\n",
+    "    w >= 0.1,                                   # minimum width\n",
+    "]\n",
+    "\n",
+    "problem = cp.Problem(objective, constraints)\n",
+    "assert problem.is_dgp(dpp=True), \"Problem must be DGP-DPP compliant\"\n",
+    "print(f\"Problem is DGP: {problem.is_dgp()}, DPP: {problem.is_dgp(dpp=True)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create the CvxpyLayer with `gp=True`\n",
+    "\n",
+    "When `gp=True`, CVXPYlayers internally transforms the GP to an equivalent convex problem in log-space, solves it, and maps the solution back. Gradients flow through this transformation automatically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "layer = CvxpyLayer(problem, parameters=[A_max, P_max], variables=[w], gp=True)\n",
+    "\n",
+    "# Solve for specific budget values\n",
+    "A_max_tch = torch.tensor(5.0, dtype=torch.float64, requires_grad=True)\n",
+    "P_max_tch = torch.tensor(3.0, dtype=torch.float64, requires_grad=True)\n",
+    "\n",
+    "(w_opt,) = layer(A_max_tch, P_max_tch)\n",
+    "print(f\"Optimal widths: {w_opt.detach().numpy().round(4)}\")\n",
+    "print(f\"Total delay:    {sum(alpha / w_opt.detach().numpy()):.4f}\")\n",
+    "print(f\"Total area:     {w_opt.sum().item():.4f} (budget: {A_max_tch.item()})\")\n",
+    "print(f\"Total power:    {(torch.tensor(beta) @ w_opt).item():.4f} (budget: {P_max_tch.item()})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sensitivity Analysis via Gradients\n",
+    "\n",
+    "The key advantage of differentiable optimization: we can compute how the optimal delay changes with respect to the budget parameters. This gives us *sensitivity* or *shadow price* information."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Compute gradient of total delay w.r.t. budgets\n",
+    "total_delay = sum(torch.tensor(alpha[i]) * (1.0 / w_opt[i]) for i in range(n_stages))\n",
+    "total_delay.backward()\n",
+    "\n",
+    "print(f\"d(delay)/d(area_budget)  = {A_max_tch.grad.item():.6f}\")\n",
+    "print(f\"d(delay)/d(power_budget) = {P_max_tch.grad.item():.6f}\")\n",
+    "print()\n",
+    "print(\"Negative gradients mean increasing the budget decreases delay.\")\n",
+    "print(f\"A unit increase in area budget reduces delay by ~{-A_max_tch.grad.item():.4f}\")\n",
+    "print(f\"A unit increase in power budget reduces delay by ~{-P_max_tch.grad.item():.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Delay vs. Area Budget Tradeoff\n",
+    "\n",
+    "Sweep the area budget and plot how the optimal delay changes. The gradient gives the local slope of this curve."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "area_values = np.linspace(1.5, 10.0, 30)\n",
+    "delays = []\n",
+    "sensitivities = []\n",
+    "P_fixed = torch.tensor(5.0, dtype=torch.float64)\n",
+    "\n",
+    "for a_val in area_values:\n",
+    "    A_tch = torch.tensor(a_val, dtype=torch.float64, requires_grad=True)\n",
+    "    (w_sol,) = layer(A_tch, P_fixed)\n",
+    "    d = sum(torch.tensor(alpha[i]) * (1.0 / w_sol[i]) for i in range(n_stages))\n",
+    "    d.backward()\n",
+    "    delays.append(d.item())\n",
+    "    sensitivities.append(A_tch.grad.item())\n",
+    "\n",
+    "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 4))\n",
+    "\n",
+    "ax1.plot(area_values, delays, 'b-', linewidth=2)\n",
+    "ax1.set_xlabel('Area Budget')\n",
+    "ax1.set_ylabel('Optimal Delay')\n",
+    "ax1.set_title('Delay vs. Area Budget')\n",
+    "ax1.grid(True, alpha=0.3)\n",
+    "\n",
+    "ax2.plot(area_values, sensitivities, 'r-', linewidth=2)\n",
+    "ax2.set_xlabel('Area Budget')\n",
+    "ax2.set_ylabel('d(delay)/d(area_budget)')\n",
+    "ax2.set_title('Sensitivity (Shadow Price)')\n",
+    "ax2.axhline(y=0, color='k', linestyle='--', alpha=0.3)\n",
+    "ax2.grid(True, alpha=0.3)\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "print(\"The sensitivity approaches zero as the area budget becomes non-binding.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/torch/predict_then_optimize.ipynb
+++ b/examples/torch/predict_then_optimize.ipynb
@@ -1,0 +1,313 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Predict-then-Optimize: Decision-Focused Learning\n",
+    "\n",
+    "This notebook demonstrates **end-to-end predict-then-optimize** with CVXPYlayers — a neural network predicts optimization parameters, and a CvxpyLayer solves the downstream optimization. We compare:\n",
+    "\n",
+    "1. **Two-stage**: Train the predictor to minimize prediction MSE, then optimize\n",
+    "2. **Decision-focused**: Train end-to-end to minimize *decision regret* (suboptimality of decisions)\n",
+    "\n",
+    "**Problem**: A neural net predicts resource costs from features, then a linear program allocates resources.\n",
+    "\n",
+    "$$\\min_x \\; \\hat{c}(\\text{features})^T x \\quad \\text{s.t.} \\; Ax \\leq b, \\; x \\geq 0$$\n",
+    "\n",
+    "**Key idea**: Minimizing prediction error doesn't minimize decision error. A cost that's wrong but leads to the same optimal decision is harmless, while a small error near a decision boundary can be catastrophic."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cvxpy as cp\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "\n",
+    "from cvxpylayers.torch import CvxpyLayer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate Synthetic Data\n",
+    "\n",
+    "Features map to true costs via a nonlinear function. Optimal decisions are computed using true costs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "torch.manual_seed(42)\n",
+    "np.random.seed(42)\n",
+    "\n",
+    "n_resources = 5   # decision variables\n",
+    "n_features = 8    # input features\n",
+    "n_constraints = 3 # resource constraints\n",
+    "n_train = 200\n",
+    "n_test = 100\n",
+    "\n",
+    "# Fixed constraint matrix and budget\n",
+    "A_constr = np.random.rand(n_constraints, n_resources) + 0.5\n",
+    "b_constr = np.ones(n_constraints) * 3.0\n",
+    "\n",
+    "# Generate features\n",
+    "X_all = torch.randn(n_train + n_test, n_features, dtype=torch.float64)\n",
+    "\n",
+    "# True cost function: nonlinear mapping from features to costs\n",
+    "W_true = torch.randn(n_features, n_resources, dtype=torch.float64) * 0.5\n",
+    "\n",
+    "def true_costs(X):\n",
+    "    \"\"\"Nonlinear feature-to-cost mapping.\"\"\"\n",
+    "    return torch.abs(X @ W_true) + 0.1  # ensure positive costs\n",
+    "\n",
+    "C_all = true_costs(X_all)\n",
+    "\n",
+    "# Split\n",
+    "X_train, X_test = X_all[:n_train], X_all[n_train:]\n",
+    "C_train, C_test = C_all[:n_train], C_all[n_train:]\n",
+    "\n",
+    "print(f\"Features: {n_features}, Resources: {n_resources}\")\n",
+    "print(f\"Train: {n_train}, Test: {n_test}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define LP and CvxpyLayer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x_var = cp.Variable(n_resources, name=\"allocation\")\n",
+    "c_param = cp.Parameter(n_resources, name=\"costs\")\n",
+    "\n",
+    "constraints = [\n",
+    "    A_constr @ x_var <= b_constr,\n",
+    "    x_var >= 0,\n",
+    "]\n",
+    "objective = cp.Minimize(c_param @ x_var)\n",
+    "problem = cp.Problem(objective, constraints)\n",
+    "assert problem.is_dpp()\n",
+    "\n",
+    "opt_layer = CvxpyLayer(problem, parameters=[c_param], variables=[x_var])\n",
+    "print(\"LP layer created.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define Prediction Network\n",
+    "\n",
+    "A small MLP maps features to predicted costs. We'll train two copies: one with MSE loss, one with decision loss."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class CostPredictor(nn.Module):\n",
+    "    def __init__(self):\n",
+    "        super().__init__()\n",
+    "        self.net = nn.Sequential(\n",
+    "            nn.Linear(n_features, 32),\n",
+    "            nn.ReLU(),\n",
+    "            nn.Linear(32, 16),\n",
+    "            nn.ReLU(),\n",
+    "            nn.Linear(16, n_resources),\n",
+    "            nn.Softplus(),  # ensure positive costs\n",
+    "        )\n",
+    "        self.double()\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        return self.net(x)\n",
+    "\n",
+    "# Two copies with same initialization\n",
+    "torch.manual_seed(123)\n",
+    "model_mse = CostPredictor()\n",
+    "torch.manual_seed(123)\n",
+    "model_dfl = CostPredictor()\n",
+    "\n",
+    "print(f\"Parameters per model: {sum(p.numel() for p in model_mse.parameters())}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Training\n",
+    "\n",
+    "**Two-stage** (MSE): minimize $\\|\\hat{c} - c_{\\text{true}}\\|^2$\n",
+    "\n",
+    "**Decision-focused** (DFL): minimize *regret* $= c_{\\text{true}}^T x(\\hat{c}) - c_{\\text{true}}^T x^\\star$, where $x(\\hat{c})$ is the decision from predicted costs and $x^\\star$ is the optimal decision."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_epochs = 50\n",
+    "batch_size = 32\n",
+    "lr = 1e-3\n",
+    "\n",
+    "# Precompute optimal decisions under true costs\n",
+    "x_stars_train = []\n",
+    "for i in range(n_train):\n",
+    "    (x_opt,) = opt_layer(C_train[i])\n",
+    "    x_stars_train.append(x_opt.detach())\n",
+    "x_stars_train = torch.stack(x_stars_train)\n",
+    "\n",
+    "opt_mse = torch.optim.Adam(model_mse.parameters(), lr=lr)\n",
+    "opt_dfl = torch.optim.Adam(model_dfl.parameters(), lr=lr)\n",
+    "\n",
+    "mse_losses_hist = []\n",
+    "dfl_losses_hist = []\n",
+    "\n",
+    "for epoch in range(n_epochs):\n",
+    "    # Random batch\n",
+    "    idx = torch.randperm(n_train)[:batch_size]\n",
+    "    X_batch = X_train[idx]\n",
+    "    C_batch = C_train[idx]\n",
+    "    x_star_batch = x_stars_train[idx]\n",
+    "\n",
+    "    # --- Two-stage (MSE) ---\n",
+    "    opt_mse.zero_grad()\n",
+    "    c_pred_mse = model_mse(X_batch)\n",
+    "    loss_mse = torch.mean((c_pred_mse - C_batch) ** 2)\n",
+    "    loss_mse.backward()\n",
+    "    opt_mse.step()\n",
+    "    mse_losses_hist.append(loss_mse.item())\n",
+    "\n",
+    "    # --- Decision-focused ---\n",
+    "    opt_dfl.zero_grad()\n",
+    "    c_pred_dfl = model_dfl(X_batch)\n",
+    "    \n",
+    "    # Solve LP with predicted costs (one at a time for stability)\n",
+    "    regrets = []\n",
+    "    for j in range(len(idx)):\n",
+    "        (x_pred,) = opt_layer(c_pred_dfl[j])\n",
+    "        # Regret = true_cost @ predicted_decision - true_cost @ optimal_decision\n",
+    "        regret = C_batch[j] @ x_pred - C_batch[j] @ x_star_batch[j]\n",
+    "        regrets.append(regret)\n",
+    "    loss_dfl = torch.mean(torch.stack(regrets))\n",
+    "    loss_dfl.backward()\n",
+    "    opt_dfl.step()\n",
+    "    dfl_losses_hist.append(loss_dfl.item())\n",
+    "\n",
+    "    if (epoch + 1) % 10 == 0:\n",
+    "        print(f\"Epoch {epoch+1:3d} | MSE loss: {loss_mse.item():.4f} | DFL regret: {loss_dfl.item():.6f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Evaluate: Decision Quality on Test Set\n",
+    "\n",
+    "What matters is not prediction accuracy, but the quality of *decisions* made using the predictions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def evaluate_model(model, X, C_true):\n",
+    "    \"\"\"Compute prediction MSE and decision regret on a dataset.\"\"\"\n",
+    "    with torch.no_grad():\n",
+    "        c_pred = model(X)\n",
+    "    pred_mse = torch.mean((c_pred - C_true) ** 2).item()\n",
+    "\n",
+    "    regrets = []\n",
+    "    for i in range(len(X)):\n",
+    "        (x_pred,) = opt_layer(c_pred[i])\n",
+    "        (x_opt,) = opt_layer(C_true[i])\n",
+    "        regret = (C_true[i] @ x_pred - C_true[i] @ x_opt).item()\n",
+    "        regrets.append(regret)\n",
+    "    avg_regret = np.mean(regrets)\n",
+    "    return pred_mse, avg_regret, regrets\n",
+    "\n",
+    "mse_pred_err, mse_regret, mse_regrets = evaluate_model(model_mse, X_test, C_test)\n",
+    "dfl_pred_err, dfl_regret, dfl_regrets = evaluate_model(model_dfl, X_test, C_test)\n",
+    "\n",
+    "print(f\"{'Method':<25} {'Prediction MSE':>15} {'Decision Regret':>15}\")\n",
+    "print(\"-\" * 55)\n",
+    "print(f\"{'Two-stage (MSE)':<25} {mse_pred_err:>15.4f} {mse_regret:>15.6f}\")\n",
+    "print(f\"{'Decision-focused (DFL)':<25} {dfl_pred_err:>15.4f} {dfl_regret:>15.6f}\")\n",
+    "print()\n",
+    "print(\"Note: DFL may have higher prediction MSE but lower decision regret.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(1, 3, figsize=(14, 4))\n",
+    "\n",
+    "# Training curves\n",
+    "ax = axes[0]\n",
+    "ax.plot(mse_losses_hist, label='Two-stage (MSE)', alpha=0.7)\n",
+    "ax.set_xlabel('Epoch')\n",
+    "ax.set_ylabel('MSE Loss')\n",
+    "ax.set_title('MSE Training Loss')\n",
+    "ax.grid(True, alpha=0.3)\n",
+    "\n",
+    "ax = axes[1]\n",
+    "ax.plot(dfl_losses_hist, label='Decision-focused', color='orange', alpha=0.7)\n",
+    "ax.set_xlabel('Epoch')\n",
+    "ax.set_ylabel('Regret')\n",
+    "ax.set_title('DFL Training Regret')\n",
+    "ax.grid(True, alpha=0.3)\n",
+    "\n",
+    "# Regret comparison\n",
+    "ax = axes[2]\n",
+    "positions = [0, 1]\n",
+    "ax.boxplot([mse_regrets, dfl_regrets], positions=positions, widths=0.5)\n",
+    "ax.set_xticks(positions)\n",
+    "ax.set_xticklabels(['Two-stage', 'Decision-focused'])\n",
+    "ax.set_ylabel('Decision Regret')\n",
+    "ax.set_title('Test Set Regret Distribution')\n",
+    "ax.grid(True, alpha=0.3, axis='y')\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/torch/robust_optimization.ipynb
+++ b/examples/torch/robust_optimization.ipynb
@@ -1,0 +1,268 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Robust Optimization: Learning Uncertainty Sets\n",
+    "\n",
+    "This notebook demonstrates **robust optimization** with CVXPYlayers — designing solutions that perform well under worst-case uncertainty, and *learning* the right amount of robustness from data.\n",
+    "\n",
+    "**Problem**: Robust least-squares regression. Given uncertain data matrix $A$, we solve:\n",
+    "\n",
+    "$$\\min_x \\; \\|Ax - b\\|_2^2 + \\gamma \\cdot \\epsilon \\cdot \\|x\\|_2$$\n",
+    "\n",
+    "The regularization term $\\gamma \\cdot \\epsilon \\cdot \\|x\\|_2$ is the robust counterpart for spectral-norm bounded perturbations $\\|\\Delta\\| \\leq \\epsilon$. The uncertainty radius $\\epsilon$ is a learnable parameter trained to minimize out-of-sample prediction error.\n",
+    "\n",
+    "**Key idea**: Too little robustness ($\\epsilon \\approx 0$) overfits; too much robustness underperforms. CVXPYlayers lets us *learn* the right $\\epsilon$ by backpropagating through the optimization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cvxpy as cp\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import torch\n",
+    "\n",
+    "from cvxpylayers.torch import CvxpyLayer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate Synthetic Data with Perturbations\n",
+    "\n",
+    "We create training data from a linear model $y = A_{\\text{true}} x_{\\text{true}} + \\text{noise}$, but the observed $A$ has measurement errors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.random.seed(42)\n",
+    "\n",
+    "n_features = 10\n",
+    "n_train = 30\n",
+    "n_val = 200\n",
+    "noise_std = 0.3\n",
+    "perturbation_std = 0.15  # measurement error in A\n",
+    "\n",
+    "# True model\n",
+    "x_true = np.random.randn(n_features)\n",
+    "x_true /= np.linalg.norm(x_true)\n",
+    "\n",
+    "# True (clean) data matrix\n",
+    "A_true = np.random.randn(n_train, n_features)\n",
+    "b_train = A_true @ x_true + noise_std * np.random.randn(n_train)\n",
+    "\n",
+    "# Observed (perturbed) training data\n",
+    "A_train = A_true + perturbation_std * np.random.randn(n_train, n_features)\n",
+    "\n",
+    "# Validation data (clean A, noisy b)\n",
+    "A_val = np.random.randn(n_val, n_features)\n",
+    "b_val = A_val @ x_true + noise_std * np.random.randn(n_val)\n",
+    "\n",
+    "print(f\"Training: {n_train} samples, {n_features} features\")\n",
+    "print(f\"Validation: {n_val} samples\")\n",
+    "print(f\"Perturbation std: {perturbation_std}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define Robust Least-Squares Layer\n",
+    "\n",
+    "The robust counterpart of least-squares with spectral norm uncertainty $\\|\\Delta\\| \\leq \\epsilon$ adds a regularization term $\\epsilon \\|x\\|_2$. This is equivalent to Tikhonov regularization, but with a principled interpretation as worst-case robustness.\n",
+    "\n",
+    "We parametrize the problem with:\n",
+    "- `b_param` — the observed response vector\n",
+    "- `epsilon` — the uncertainty radius (to be learned)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x_var = cp.Variable(n_features, name=\"x\")\n",
+    "b_param = cp.Parameter(n_train, name=\"b\")\n",
+    "epsilon = cp.Parameter(nonneg=True, name=\"epsilon\")\n",
+    "\n",
+    "# A_train is fixed (not a parameter for simplicity)\n",
+    "A_np = A_train.copy()\n",
+    "\n",
+    "# Robust counterpart: ||Ax - b||^2 + epsilon * ||x||_2\n",
+    "objective = cp.Minimize(\n",
+    "    cp.sum_squares(A_np @ x_var - b_param) + epsilon * cp.norm(x_var, 2)\n",
+    ")\n",
+    "problem = cp.Problem(objective)\n",
+    "assert problem.is_dpp()\n",
+    "\n",
+    "layer = CvxpyLayer(problem, parameters=[b_param, epsilon], variables=[x_var])\n",
+    "print(\"Robust least-squares layer created.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Solve for Different Uncertainty Radii\n",
+    "\n",
+    "Sweep $\\epsilon$ to see how robustness affects training and validation error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "b_tch = torch.tensor(b_train, dtype=torch.float64)\n",
+    "A_val_tch = torch.tensor(A_val, dtype=torch.float64)\n",
+    "b_val_tch = torch.tensor(b_val, dtype=torch.float64)\n",
+    "A_train_tch = torch.tensor(A_train, dtype=torch.float64)\n",
+    "\n",
+    "eps_values = np.logspace(-2, 2, 30)\n",
+    "train_errors = []\n",
+    "val_errors = []\n",
+    "\n",
+    "for eps_val in eps_values:\n",
+    "    eps_tch = torch.tensor(eps_val, dtype=torch.float64)\n",
+    "    (x_sol,) = layer(b_tch, eps_tch)\n",
+    "    \n",
+    "    train_err = torch.mean((A_train_tch @ x_sol - b_tch) ** 2).item()\n",
+    "    val_err = torch.mean((A_val_tch @ x_sol - b_val_tch) ** 2).item()\n",
+    "    train_errors.append(train_err)\n",
+    "    val_errors.append(val_err)\n",
+    "\n",
+    "best_idx = np.argmin(val_errors)\n",
+    "print(f\"Best epsilon (grid search): {eps_values[best_idx]:.4f}\")\n",
+    "print(f\"Best validation MSE:        {val_errors[best_idx]:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Learn Epsilon via SGD\n",
+    "\n",
+    "Instead of grid search, use gradient descent to find the optimal $\\epsilon$. CVXPYlayers differentiates through the solve, so we can directly minimize validation error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Learnable epsilon (log-parameterized for positivity)\n",
+    "log_eps = torch.tensor(0.0, dtype=torch.float64, requires_grad=True)\n",
+    "optimizer = torch.optim.Adam([log_eps], lr=0.1)\n",
+    "\n",
+    "losses = []\n",
+    "eps_trajectory = []\n",
+    "\n",
+    "for step in range(50):\n",
+    "    optimizer.zero_grad()\n",
+    "    eps_tch = torch.exp(log_eps)\n",
+    "    (x_sol,) = layer(b_tch, eps_tch)\n",
+    "    \n",
+    "    # Minimize validation MSE\n",
+    "    val_loss = torch.mean((A_val_tch @ x_sol - b_val_tch) ** 2)\n",
+    "    val_loss.backward()\n",
+    "    optimizer.step()\n",
+    "    \n",
+    "    losses.append(val_loss.item())\n",
+    "    eps_trajectory.append(eps_tch.item())\n",
+    "\n",
+    "learned_eps = torch.exp(log_eps).item()\n",
+    "print(f\"Learned epsilon: {learned_eps:.4f}\")\n",
+    "print(f\"Final validation MSE: {losses[-1]:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Results: Robust vs. Nominal"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(1, 3, figsize=(14, 4))\n",
+    "\n",
+    "# Plot 1: Train/val error vs epsilon\n",
+    "ax = axes[0]\n",
+    "ax.semilogx(eps_values, train_errors, 'b-', label='Train MSE', linewidth=2)\n",
+    "ax.semilogx(eps_values, val_errors, 'r-', label='Validation MSE', linewidth=2)\n",
+    "ax.axvline(x=learned_eps, color='g', linestyle='--', label=f'Learned ε={learned_eps:.2f}')\n",
+    "ax.axvline(x=eps_values[best_idx], color='orange', linestyle=':', label=f'Grid best ε={eps_values[best_idx]:.2f}')\n",
+    "ax.set_xlabel('Uncertainty Radius (ε)')\n",
+    "ax.set_ylabel('MSE')\n",
+    "ax.set_title('Error vs. Robustness')\n",
+    "ax.legend(fontsize=8)\n",
+    "ax.grid(True, alpha=0.3)\n",
+    "\n",
+    "# Plot 2: SGD convergence\n",
+    "ax = axes[1]\n",
+    "ax.plot(losses, 'g-', linewidth=2)\n",
+    "ax.set_xlabel('SGD Step')\n",
+    "ax.set_ylabel('Validation MSE')\n",
+    "ax.set_title('Learning Curve')\n",
+    "ax.grid(True, alpha=0.3)\n",
+    "\n",
+    "# Plot 3: Epsilon trajectory\n",
+    "ax = axes[2]\n",
+    "ax.plot(eps_trajectory, 'g-', linewidth=2)\n",
+    "ax.axhline(y=eps_values[best_idx], color='orange', linestyle=':', label='Grid search best')\n",
+    "ax.set_xlabel('SGD Step')\n",
+    "ax.set_ylabel('ε')\n",
+    "ax.set_title('Learned ε Trajectory')\n",
+    "ax.legend(fontsize=8)\n",
+    "ax.grid(True, alpha=0.3)\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "# Compare nominal vs robust\n",
+    "eps_nominal = torch.tensor(0.0, dtype=torch.float64)\n",
+    "(x_nominal,) = layer(b_tch, eps_nominal)\n",
+    "eps_robust = torch.tensor(learned_eps, dtype=torch.float64)\n",
+    "(x_robust,) = layer(b_tch, eps_robust)\n",
+    "\n",
+    "nom_val_err = torch.mean((A_val_tch @ x_nominal - b_val_tch) ** 2).item()\n",
+    "rob_val_err = torch.mean((A_val_tch @ x_robust - b_val_tch) ** 2).item()\n",
+    "\n",
+    "print(f\"Nominal (ε=0) validation MSE:   {nom_val_err:.4f}\")\n",
+    "print(f\"Robust (ε={learned_eps:.2f}) validation MSE: {rob_val_err:.4f}\")\n",
+    "print(f\"Improvement: {(nom_val_err - rob_val_err) / nom_val_err * 100:.1f}%\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/torch/torch_example.py
+++ b/examples/torch/torch_example.py
@@ -26,17 +26,22 @@ print(solution)
 print(A_tch.grad)
 print(b_tch.grad)
 
-# On the GPU:
-device = torch.device("cuda")
-cvxpylayer = CvxpyLayer(problem, parameters=[A, b], variables=[x], solver=cp.CUCLARABEL).to(device)
-A_tch = torch.randn(m, n, requires_grad=True, device=device)
-b_tch = torch.randn(m, requires_grad=True, device=device)
+# On the GPU (requires CuClarabel):
+try:
+    device = torch.device("cuda")
+    cvxpylayer = CvxpyLayer(
+        problem, parameters=[A, b], variables=[x], solver=cp.CUCLARABEL
+    ).to(device)
+    A_tch = torch.randn(m, n, requires_grad=True, device=device)
+    b_tch = torch.randn(m, requires_grad=True, device=device)
 
-# solve the problem
-(solution,) = cvxpylayer(A_tch, b_tch)
+    # solve the problem
+    (solution,) = cvxpylayer(A_tch, b_tch)
 
-# compute the gradient of the sum of the solution with respect to A, b
-solution.sum().backward()
-print(solution)
-print(A_tch.grad)
-print(b_tch.grad)
+    # compute the gradient of the sum of the solution with respect to A, b
+    solution.sum().backward()
+    print(solution)
+    print(A_tch.grad)
+    print(b_tch.grad)
+except Exception as e:
+    print(f"GPU example skipped: {e}")


### PR DESCRIPTION
## Summary
- Add 5 new Jupyter notebooks covering previously missing feature examples:
  - **gp_circuit_sizing**: Geometric programs with `gp=True` and `pos=True` variables, sensitivity analysis
  - **batched_portfolio**: Batched solving, parameter broadcasting, and dual variable extraction
  - **robust_optimization**: Learning the right uncertainty set radius from data via SGD
  - **predict_then_optimize**: Neural net + CvxpyLayer end-to-end pipeline, decision-focused vs two-stage learning
  - **convex_regression**: Fitting convex piecewise-linear (max-of-affines) functions to data
- Fix existing `torch_example.py` and `jax_example.py` to handle missing CuClarabel gracefully
- Add new notebooks to the docs examples page (`docs/examples/index.md`) under Engineering and new "Optimization Techniques" section

## Test plan
- [x] All 5 new notebooks verified via `jupyter nbconvert --execute`
- [x] `examples/torch/torch_example.py` runs cleanly (GPU section skipped gracefully)
- [x] `examples/jax/jax_example.py` runs cleanly with default solver

🤖 Generated with [Claude Code](https://claude.com/claude-code)