### PR TITLE
fix: silence sparse tensor invariant warning in PyTorch

### DIFF
--- a/src/cvxpylayers/torch/cvxpylayer.py
+++ b/src/cvxpylayers/torch/cvxpylayer.py
@@ -503,8 +503,14 @@ def scipy_csr_to_torch_csr(
     row_ptr = scipy_csr.indptr
     num_rows, num_cols = scipy_csr.shape  # type: ignore[misc]
 
-    # Create the torch sparse csr_tensor
-    with warnings.catch_warnings():
+    # Create the torch sparse csr_tensor.
+    # Explicitly disable invariant checks for performance — the input
+    # comes from scipy CSR, which already guarantees sorted, deduplicated
+    # indices.  This also silences the PyTorch warning about implicit state.
+    with (
+        torch.sparse.check_sparse_tensor_invariants(enable=False),
+        warnings.catch_warnings(),
+    ):
         warnings.filterwarnings(
             "ignore",
             message="Sparse CSR tensor support is in beta state",


### PR DESCRIPTION
## Summary
- Explicitly opt out of sparse tensor invariant checks via `torch.sparse.check_sparse_tensor_invariants(enable=False)` when converting scipy CSR matrices to torch CSR tensors
- The input from scipy already guarantees sorted, deduplicated indices, so the checks are unnecessary and this is the approach PyTorch recommends
- Silences the `UserWarning: Sparse invariant checks are implicitly disabled` that fires on recent PyTorch versions

## Test plan
- [x] Verified fix with `python -W error::UserWarning` — no warnings raised
- [x] Verified forward and backward pass produce correct results on batched least-squares example