### PR TITLE
Loosen dependency pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,16 +46,16 @@ Documentation = "https://github.com/cvxpy/cvxpylayers"
 
 [project.optional-dependencies]
 torch = ["torch>=2.0.0", "diffcp>=1.1.0"]
-mlx = ["mlx==0.27.1"]
-metal = ["mlx-metal==0.27.1"]
+mlx = ["mlx>=0.27.1"]
+metal = ["mlx-metal>=0.27.1"]
 jax = ["jax>=0.4.0", "jaxlib>=0.4.0"]
 all = [
     "torch>=2.0.0",
     "diffqcp>=0.4.4",
- "jax>=0.4.0",
- "jaxlib>=0.4.0",
- "mlx==0.27.1",
- "mlx-metal==0.27.1",
+    "jax>=0.4.0",
+    "jaxlib>=0.4.0",
+    "mlx>=0.27.1",
+    "mlx-metal>=0.27.1",
 ]
 
 [tool.hatch.metadata]
@@ -69,18 +69,18 @@ include = ["/src", "/examples", "/README.md", "/LICENSE"]
 
 [dependency-groups]
 dev = [
-    "codespell==2.4.1",
-    "covdefaults==2.3.0",
-    "coverage[toml]==7.6.12",
-    "pre-commit==4.2.0",
-    "pre-commit-hooks==5.0.0",
-    "pylint==3.3.4",
-    "pytest==8.4.1",
-    "pytest-cov==6.2.1",
-    "ruff==0.12.7",
-    "ty==0.0.1a16",
-    "yamllint==1.35.1",
-    "ipykernel==6.30.0",
+    "codespell>=2.4.1",
+    "covdefaults>=2.3.0",
+    "coverage[toml]>=7.6.12",
+    "pre-commit>=4.2.0",
+    "pre-commit-hooks>=5.0.0",
+    "pylint>=3.3.4",
+    "pytest>=8.4.1",
+    "pytest-cov>=6.2.1",
+    "ruff>=0.12.7",
+    "ty>=0.0.1a16",
+    "yamllint>=1.35.1",
+    "ipykernel>=6.30.0",
 ]
 doc = [
     "sphinx >= 8.0.0",


### PR DESCRIPTION
## Summary
- relax exact pins for MLX optional dependencies to lower bounds
- relax exact pins in the dev dependency group to lower bounds
- normalize indentation in the all extra dependency list

## Testing
- python -c "import tomllib; tomllib.load(open('pyproject.toml','rb')); print('pyproject ok')"
- python -m pytest -q *(fails during collection because diffcp is not installed in this environment)*