### PR TITLE
Compatibility with new var and param id bookkeeping in CVXPY

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
       - name: Install dependencies
         run: |
-          uv pip install --system -e ".[torch,jax]"
+          uv pip install --system -e ".[torch,jax]" "cvxpy @ git+https://github.com/cvxpy/cvxpy.git"
           uv pip install --system "mlx[cpu]" mpax pytest
       - name: Install Moreau
         run: uv pip install --system moreau --extra-index-url https://${FURY_TOKEN}:@pypi.fury.io/optimalintellect/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
+          pip install -e "." "cvxpy @ git+https://github.com/cvxpy/cvxpy.git"
           # Install doc dependencies
           pip install sphinx furo myst-parser sphinx-design sphinx-copybutton nbsphinx sphinx-autobuild
           # Install frameworks for autodoc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
 maintainers = [{ name = "P. Nobel", email = "parthnobel@berkeley.edu" }]
 requires-python = ">=3.11"
 dependencies = [
-    "cvxpy>=1.8.2",
+    "cvxpy>=1.9",
     "diffcp>=1.1.0",
     "numpy>=1.22.4",
     "scipy>=1.13.0",

--- a/src/cvxpylayers/jax/cvxpylayer.py
+++ b/src/cvxpylayers/jax/cvxpylayer.py
@@ -78,15 +78,20 @@ def _flatten_and_batch_params(
         if ctx.batch_sizes[i] == 0 and batch:  # type: ignore[index]
             # Unbatched parameter - expand to match batch size
             param_expanded = jnp.broadcast_to(jnp.expand_dims(param, 0), batch + param.shape)
+        else:
+            param_expanded = param
+
+        triu = ctx.param_triu_indices[i] if ctx.param_triu_indices else None
+        if triu is not None:
+            # Symmetric/PSD/NSD parameter: CVXPY canonicalizes to upper triangle.
+            triu_rows, triu_cols = triu
+            flattened_params[ctx.user_order_to_col_order[i]] = param_expanded[
+                ..., triu_rows, triu_cols
+            ]
+        else:
             flattened_params[ctx.user_order_to_col_order[i]] = _reshape_fortran(
                 param_expanded,
-                batch + (-1,),
-            )
-        else:
-            # Already batched or no batch dimension needed
-            flattened_params[ctx.user_order_to_col_order[i]] = _reshape_fortran(
-                param,
-                batch + (-1,),
+                batch + (-1,) if batch else (-1,),
             )
 
     # Add constant 1.0 column for offset terms in canonical form

--- a/src/cvxpylayers/mlx/cvxpylayer.py
+++ b/src/cvxpylayers/mlx/cvxpylayer.py
@@ -73,6 +73,7 @@ def _flatten_and_batch_params(
     params: tuple[mx.array, ...],
     ctx: pa.LayersContext,
     batch: tuple,
+    param_triu_G: list[mx.array | None],
 ) -> mx.array:
     """Flatten and batch parameters into a single stacked array.
 
@@ -98,14 +99,12 @@ def _flatten_and_batch_params(
         else:
             param_expanded = param
 
-        triu = ctx.param_triu_indices[i] if ctx.param_triu_indices else None
-        if triu is not None:
-            # Symmetric/PSD/NSD parameter: CVXPY canonicalizes to upper triangle.
-            triu_rows = np.array(triu[0])
-            triu_cols = np.array(triu[1])
-            flattened_params[ctx.user_order_to_col_order[i]] = param_expanded[
-                ..., triu_rows, triu_cols
-            ]
+        G = param_triu_G[i]
+        if G is not None:
+            # MLX doesn't support fancy indexing, so we use a precomputed selection
+            # matrix G (shape k times n2) so that upper_tri(C) = G @ C.flatten().
+            param_flat = param_expanded.reshape(param_expanded.shape[:-2] + (-1,))
+            flattened_params[ctx.user_order_to_col_order[i]] = param_flat @ G.T
         else:
             flattened_params[ctx.user_order_to_col_order[i]] = _reshape_fortran(
                 param_expanded,
@@ -357,6 +356,20 @@ class CvxpyLayer:
         self._q_np: np.ndarray = _scipy_csr_to_dense(self.ctx.q.tocsr())  # type: ignore[assignment]
         self._A_np: np.ndarray = _scipy_csr_to_dense(self.ctx.reduced_A.reduced_mat)  # type: ignore[attr-defined, assignment]
 
+        # Precompute selection matrices for symmetric/hermitian/PSD/NSD parameters.
+        self._param_triu_G: list[mx.array | None] = []
+        for j, triu in enumerate(self.ctx.param_triu_indices):
+            if triu is not None:
+                triu_rows, triu_cols = triu
+                k = len(triu_rows)
+                n = self.ctx.parameters[j].shape[-1]
+                G_np = np.zeros((k, n * n), dtype=np.float64)
+                for idx, (r, c) in enumerate(zip(triu_rows, triu_cols)):
+                    G_np[idx, r * n + c] = 1.0
+                self._param_triu_G.append(mx.array(G_np))
+            else:
+                self._param_triu_G.append(None)
+
     def __call__(
         self,
         *params: mx.array,
@@ -398,7 +411,7 @@ class CvxpyLayer:
         params = _apply_gp_log_transform(params, self.ctx)
 
         # Flatten and batch parameters
-        p_stack = _flatten_and_batch_params(params, self.ctx, batch)
+        p_stack = _flatten_and_batch_params(params, self.ctx, batch, self._param_triu_G)
 
         # Get dtype from input parameters to ensure type matching
         param_dtype = params[0].dtype

--- a/src/cvxpylayers/mlx/cvxpylayer.py
+++ b/src/cvxpylayers/mlx/cvxpylayer.py
@@ -95,15 +95,20 @@ def _flatten_and_batch_params(
         if ctx.batch_sizes[i] == 0 and batch:  # type: ignore[index]
             # Unbatched parameter - expand to match batch size
             param_expanded = mx.broadcast_to(mx.expand_dims(param, axis=0), batch + param.shape)
+        else:
+            param_expanded = param
+
+        triu = ctx.param_triu_indices[i] if ctx.param_triu_indices else None
+        if triu is not None:
+            # Symmetric/PSD/NSD parameter: CVXPY canonicalizes to upper triangle.
+            triu_rows, triu_cols = triu
+            flattened_params[ctx.user_order_to_col_order[i]] = param_expanded[
+                ..., triu_rows, triu_cols
+            ]
+        else:
             flattened_params[ctx.user_order_to_col_order[i]] = _reshape_fortran(
                 param_expanded,
-                batch + (-1,),
-            )
-        else:
-            # Already batched or no batch dimension needed
-            flattened_params[ctx.user_order_to_col_order[i]] = _reshape_fortran(
-                param,
-                batch + (-1,),
+                batch + (-1,) if batch else (-1,),
             )
 
     # Add constant 1.0 column for offset terms in canonical form

--- a/src/cvxpylayers/mlx/cvxpylayer.py
+++ b/src/cvxpylayers/mlx/cvxpylayer.py
@@ -101,7 +101,8 @@ def _flatten_and_batch_params(
         triu = ctx.param_triu_indices[i] if ctx.param_triu_indices else None
         if triu is not None:
             # Symmetric/PSD/NSD parameter: CVXPY canonicalizes to upper triangle.
-            triu_rows, triu_cols = triu
+            triu_rows = np.array(triu[0])
+            triu_cols = np.array(triu[1])
             flattened_params[ctx.user_order_to_col_order[i]] = param_expanded[
                 ..., triu_rows, triu_cols
             ]

--- a/src/cvxpylayers/torch/cvxpylayer.py
+++ b/src/cvxpylayers/torch/cvxpylayer.py
@@ -111,14 +111,20 @@ def _flatten_and_batch_params(
         if ctx.batch_sizes[i] == 0:  # type: ignore[index]
             # Unbatched parameter - expand to match batch size
             param_expanded = param.unsqueeze(0).expand(effective_batch + param.shape)
+        else:
+            param_expanded = param
+
+        triu = ctx.param_triu_indices[i] if ctx.param_triu_indices else None
+        if triu is not None:
+            # Symmetric/PSD/NSD parameter: CVXPY canonicalizes to upper triangle.
+            # Extract it so p_stack matches the canonical form's column count.
+            triu_rows, triu_cols = triu
+            flattened_params[ctx.user_order_to_col_order[i]] = param_expanded[
+                ..., triu_rows, triu_cols
+            ]
+        else:
             flattened_params[ctx.user_order_to_col_order[i]] = _reshape_fortran(
                 param_expanded,
-                effective_batch + (-1,),
-            )
-        else:
-            # Already batched
-            flattened_params[ctx.user_order_to_col_order[i]] = _reshape_fortran(
-                param,
                 effective_batch + (-1,),
             )
 

--- a/src/cvxpylayers/utils/parse_args.py
+++ b/src/cvxpylayers/utils/parse_args.py
@@ -7,7 +7,6 @@ import cvxpy as cp
 import cvxpy.constraints
 import numpy as np
 import scipy.sparse
-from cvxpy.reductions.cvx_attr2constr import CvxAttr2Constr
 from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ParamConeProg
 from cvxpy.utilities import scopes
 
@@ -175,27 +174,6 @@ class LayersContext:
         self.batch_sizes = batch_sizes
         return ()
 
-
-def _compose_constr_id_map(chain: Any, inverse_data: list) -> dict[int, int]:
-    """Compose constraint ID maps across all reduction steps.
-
-    Each reduction step may assign fresh IDs. This traces each original
-    constraint ID through every step's cons_id_map and returns {orig_id: final_id}.
-    """
-    result: dict[int, int] = {}
-    for reduction, inv in zip(chain.reductions, inverse_data):
-        step_map: dict[int, int] = {}
-        if isinstance(reduction, CvxAttr2Constr) and len(inv) == 3:
-            # CvxAttr2Constr stores (id2new_var, id2old_var, cons_id_map) or () when it was a no-op.
-            _, _, step_map = inv
-        elif hasattr(inv, "cons_id_map") and isinstance(inv.cons_id_map, dict):
-            step_map = inv.cons_id_map
-        if step_map:
-            result = {orig: step_map.get(cur, cur) for orig, cur in result.items()}
-            for orig_id, new_id in step_map.items():
-                if orig_id not in result:
-                    result[orig_id] = new_id
-    return result
 
 
 def _build_dual_var_map(problem: cp.Problem) -> dict[int, cp.Constraint]:
@@ -528,7 +506,7 @@ def parse_args(
             param_id_map = {k: v[0] for k, v in chain.compose_param_id_map().items()}
 
         # In newer CVXPY PSD is converted to SvecPSD with fresh IDs
-        constr_id_map = _compose_constr_id_map(chain, inverse_data)
+        constr_id_map = chain.compose_constr_id_map(inverse_data)
 
     param_prob = data[cp.settings.PARAM_PROB]  # type: ignore[attr-defined]
     cone_dims = data["dims"]

--- a/src/cvxpylayers/utils/parse_args.py
+++ b/src/cvxpylayers/utils/parse_args.py
@@ -490,7 +490,7 @@ def parse_args(
             param_id_map: dict[int, int] = {}  # GP params handled via gp_param_to_log_param
         else:
             # Standard DCP path
-            data, chain, inverse_data = problem.get_problem_data(
+            data, chain, _ = problem.get_problem_data(
                 solver=solver,
                 gp=False,
                 verbose=verbose,

--- a/src/cvxpylayers/utils/parse_args.py
+++ b/src/cvxpylayers/utils/parse_args.py
@@ -1,7 +1,6 @@
 import contextlib
-from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Generator, Literal, Protocol
+from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 import cvxpy as cp
 import cvxpy.constraints
@@ -12,31 +11,6 @@ from cvxpy.utilities import scopes
 
 import cvxpylayers.interfaces
 from cvxpylayers._quad_form_dpp import SUPPORTS_QUAD_OBJ
-
-
-@contextmanager
-def _qf_scope(active: bool) -> Generator[None, None, None]:
-    """Set quad_form_dpp_scope_active to `active` for the duration of the block.
-
-    CVXPY's quad_form_dpp_scope() generator lacks try/finally around its yield,
-    so any exception inside the with-block leaves the scope flag permanently set.
-    This wrapper fixes that by restoring the flag unconditionally.
-
-    Use active=True  to enter the scope (parametric quad_form P allowed).
-    Use active=False to suspend it (e.g. during constraint DPP checks).
-    """
-    if hasattr(scopes, "_thread_local"):
-        obj: Any = scopes._thread_local  # type: ignore[attr-defined]
-        attr = "quad_form_dpp_scope_active"
-    else:
-        obj = scopes
-        attr = "_quad_form_dpp_scope_active"
-    prev = getattr(obj, attr, False)
-    setattr(obj, attr, active)
-    try:
-        yield
-    finally:
-        setattr(obj, attr, prev)
 
 
 if TYPE_CHECKING:
@@ -330,7 +304,7 @@ def _validate_problem(
         if not problem.objective.is_dcp(dpp=True):  # type: ignore[call-arg]
             raise ValueError("Problem must be DPP.")
         # Constraints: check WITHOUT scope (parametric quad_form P rejected).
-        with _qf_scope(False):
+        with scopes.suspend_quad_form_dpp_scope():
             for c in problem.constraints:
                 if not c.is_dcp(dpp=True):  # type: ignore[call-arg]
                     raise ValueError(
@@ -458,7 +432,7 @@ def parse_args(
 
     # For QP-capable solvers, enter quad_form_dpp_scope so that
     # parametric quad_form(x, P) passes DPP validation and canonicalization.
-    with (_qf_scope(True) if solver in SUPPORTS_QUAD_OBJ else contextlib.nullcontext()):
+    with (scopes.quad_form_dpp_scope() if solver in SUPPORTS_QUAD_OBJ else contextlib.nullcontext()):
         # Validate problem is DPP (disciplined parametrized programming)
         _validate_problem(problem, variables, parameters, gp, dual_var_to_constraint)
 

--- a/src/cvxpylayers/utils/parse_args.py
+++ b/src/cvxpylayers/utils/parse_args.py
@@ -473,7 +473,7 @@ def parse_args(
             gp_param_to_log_param = dgp2dcp.canon_methods._parameters
 
             # Get problem data from the already-transformed DCP problem
-            data, chain, inverse_data = dcp_problem.get_problem_data(
+            data, chain, _ = dcp_problem.get_problem_data(
                 solver=solver,
                 gp=False,
                 verbose=verbose,

--- a/src/cvxpylayers/utils/parse_args.py
+++ b/src/cvxpylayers/utils/parse_args.py
@@ -14,9 +14,6 @@ from cvxpy.utilities import scopes
 import cvxpylayers.interfaces
 from cvxpylayers._quad_form_dpp import SUPPORTS_QUAD_OBJ
 
-# guard import for backward compatibility with older CVXPY versions without SvecPSD
-_SVEC_PSD = getattr(cvxpy.constraints, "SvecPSD", None)
-
 
 @contextmanager
 def _safe_qf_scope() -> Generator[None, None, None]:
@@ -298,24 +295,15 @@ def _build_constr_id_to_slice(param_prob: ParamConeProg) -> dict[int, slice]:
     cur_idx = 0
 
     # Process each cone type in canonical order
-    if _SVEC_PSD is not None:
-        cone_types = [
-            cvxpy.constraints.Zero,
-            cvxpy.constraints.NonNeg,
-            cvxpy.constraints.SOC,
-            _SVEC_PSD,
-            cvxpy.constraints.ExpCone,
-            cvxpy.constraints.PowCone3D,
-        ]
-    else:
-        cone_types = [
-            cvxpy.constraints.Zero,
-            cvxpy.constraints.NonNeg,
-            cvxpy.constraints.SOC,
-            cvxpy.constraints.PSD,
-            cvxpy.constraints.ExpCone,
-            cvxpy.constraints.PowCone3D,
-        ]
+    cone_types = [
+        cvxpy.constraints.Zero,
+        cvxpy.constraints.NonNeg,
+        cvxpy.constraints.SOC,
+        cvxpy.constraints.PSD,
+        cvxpy.constraints.SvecPSD,
+        cvxpy.constraints.ExpCone,
+        cvxpy.constraints.PowCone3D,
+    ]
 
     for cone_type in cone_types:
         for c in param_prob.constr_map.get(cone_type, []):

--- a/src/cvxpylayers/utils/parse_args.py
+++ b/src/cvxpylayers/utils/parse_args.py
@@ -1,6 +1,7 @@
 import contextlib
+from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, Protocol
+from typing import TYPE_CHECKING, Any, Generator, Literal, Protocol
 
 import cvxpy as cp
 import cvxpy.constraints
@@ -15,6 +16,29 @@ from cvxpylayers._quad_form_dpp import SUPPORTS_QUAD_OBJ
 
 # guard import for backward compatibility with older CVXPY versions without SvecPSD
 _SVEC_PSD = getattr(cvxpy.constraints, "SvecPSD", None)
+
+
+@contextmanager
+def _safe_qf_scope() -> Generator[None, None, None]:
+    """quad_form_dpp_scope with a proper try/finally.
+
+    CVXPY's quad_form_dpp_scope() generator lacks try/finally around its yield,
+    so any exception inside the with-block leaves the scope flag permanently set.
+    This wrapper fixes that by restoring the flag unconditionally.
+    """
+    if hasattr(scopes, "_thread_local"):
+        obj: Any = scopes._thread_local  # type: ignore[attr-defined]
+        attr = "quad_form_dpp_scope_active"
+    else:
+        obj = scopes
+        attr = "_quad_form_dpp_scope_active"
+    prev = getattr(obj, attr, False)
+    setattr(obj, attr, True)
+    try:
+        yield
+    finally:
+        setattr(obj, attr, prev)
+
 
 if TYPE_CHECKING:
     import torch
@@ -474,21 +498,14 @@ def parse_args(
     # Build dual variable map for O(1) constraint lookup
     dual_var_to_constraint = _build_dual_var_map(problem)
 
+    if solver is None:
+        solver = "DIFFCP"
+
     # For QP-capable solvers, enter quad_form_dpp_scope so that
     # parametric quad_form(x, P) passes DPP validation and canonicalization.
-    effective_solver = solver or "DIFFCP"
-    qf_scope = (
-        scopes.quad_form_dpp_scope()  # pyright: ignore[reportAttributeAccessIssue]
-        if effective_solver in SUPPORTS_QUAD_OBJ
-        else contextlib.nullcontext()
-    )
-
-    with qf_scope:
+    with (_safe_qf_scope() if solver in SUPPORTS_QUAD_OBJ else contextlib.nullcontext()):
         # Validate problem is DPP (disciplined parametrized programming)
         _validate_problem(problem, variables, parameters, gp, dual_var_to_constraint)
-
-        if solver is None:
-            solver = "DIFFCP"
 
         # Handle GP problems using native CVXPY reduction (cvxpy >= 1.7.4)
         gp_param_to_log_param = None

--- a/src/cvxpylayers/utils/parse_args.py
+++ b/src/cvxpylayers/utils/parse_args.py
@@ -570,12 +570,12 @@ def parse_args(
     if gp and gp_param_to_log_param:
         gp_log_mask = tuple(p in gp_param_to_log_param for p in parameters)
 
-    # Pre-compute upper-triangle indices for (symmetric/hermitian attributes) parameters
-    # that CVXPY lowered to their upper-tri vector form
+    # Pre-compute upper-triangle indices for (symmetric/hermitian/PSD/NSD attributes)
+    # parameters that CVXPY lowered to their upper-tri vector form
     triu_list: list[tuple[tuple[int, ...], tuple[int, ...]] | None] = []
     for p in parameters:
         if getattr(p, "_has_dim_reducing_attr", False) and p.id in param_id_map:
-            if p.attributes.get("symmetric") or p.attributes.get("hermitian"):
+            if any(p.attributes.get(a) for a in ("symmetric", "hermitian", "PSD", "NSD")):
                 n = p.shape[-1]
                 rows, cols = np.triu_indices(n)
                 triu_list.append((tuple(rows.tolist()), tuple(cols.tolist())))

--- a/src/cvxpylayers/utils/parse_args.py
+++ b/src/cvxpylayers/utils/parse_args.py
@@ -16,12 +16,15 @@ from cvxpylayers._quad_form_dpp import SUPPORTS_QUAD_OBJ
 
 
 @contextmanager
-def _safe_qf_scope() -> Generator[None, None, None]:
-    """quad_form_dpp_scope with a proper try/finally.
+def _qf_scope(active: bool) -> Generator[None, None, None]:
+    """Set quad_form_dpp_scope_active to `active` for the duration of the block.
 
     CVXPY's quad_form_dpp_scope() generator lacks try/finally around its yield,
     so any exception inside the with-block leaves the scope flag permanently set.
     This wrapper fixes that by restoring the flag unconditionally.
+
+    Use active=True  to enter the scope (parametric quad_form P allowed).
+    Use active=False to suspend it (e.g. during constraint DPP checks).
     """
     if hasattr(scopes, "_thread_local"):
         obj: Any = scopes._thread_local  # type: ignore[attr-defined]
@@ -30,7 +33,7 @@ def _safe_qf_scope() -> Generator[None, None, None]:
         obj = scopes
         attr = "_quad_form_dpp_scope_active"
     prev = getattr(obj, attr, False)
-    setattr(obj, attr, True)
+    setattr(obj, attr, active)
     try:
         yield
     finally:
@@ -349,27 +352,13 @@ def _validate_problem(
         if not problem.objective.is_dcp(dpp=True):  # type: ignore[call-arg]
             raise ValueError("Problem must be DPP.")
         # Constraints: check WITHOUT scope (parametric quad_form P rejected).
-        # Temporarily deactivate the scope so that quad_form(x, P) in
-        # constraints is correctly flagged as non-DPP.
-        # Newer CVXPY stores the flag in a thread-local while older versions use
-        # a plain module attribute.
-        if hasattr(scopes, "_thread_local"):
-            _scope_obj: Any = scopes._thread_local  # type: ignore[attr-defined]
-            _scope_attr = "quad_form_dpp_scope_active"
-        else:
-            _scope_obj = scopes
-            _scope_attr = "_quad_form_dpp_scope_active"
-        prev = getattr(_scope_obj, _scope_attr, False)
-        setattr(_scope_obj, _scope_attr, False)
-        try:
+        with _qf_scope(False):
             for c in problem.constraints:
                 if not c.is_dcp(dpp=True):  # type: ignore[call-arg]
                     raise ValueError(
                         "Problem must be DPP. Note: quad_form(x, P) with parametric P "
                         "is only supported in the objective, not in constraints."
                     )
-        finally:
-            setattr(_scope_obj, _scope_attr, prev)
     else:
         if not problem.is_dcp(dpp=True):  # type: ignore[call-arg]
             raise ValueError("Problem must be DPP.")
@@ -491,7 +480,7 @@ def parse_args(
 
     # For QP-capable solvers, enter quad_form_dpp_scope so that
     # parametric quad_form(x, P) passes DPP validation and canonicalization.
-    with (_safe_qf_scope() if solver in SUPPORTS_QUAD_OBJ else contextlib.nullcontext()):
+    with (_qf_scope(True) if solver in SUPPORTS_QUAD_OBJ else contextlib.nullcontext()):
         # Validate problem is DPP (disciplined parametrized programming)
         _validate_problem(problem, variables, parameters, gp, dual_var_to_constraint)
 

--- a/src/cvxpylayers/utils/parse_args.py
+++ b/src/cvxpylayers/utils/parse_args.py
@@ -506,7 +506,7 @@ def parse_args(
             param_id_map = {k: v[0] for k, v in chain.compose_param_id_map().items()}
 
         # In newer CVXPY PSD is converted to SvecPSD with fresh IDs
-        constr_id_map = chain.compose_constr_id_map(inverse_data)
+        constr_id_map = chain.compose_constr_id_map()
 
     param_prob = data[cp.settings.PARAM_PROB]  # type: ignore[attr-defined]
     cone_dims = data["dims"]

--- a/src/cvxpylayers/utils/parse_args.py
+++ b/src/cvxpylayers/utils/parse_args.py
@@ -521,7 +521,10 @@ def parse_args(
             )
 
             # In newer CVXPY, lowered variables and parameters receive fresh IDs
-            var_id_map = {k: v[0] for k, v in chain.compose_var_id_map().items()}
+            raw_vmap = chain.compose_var_id_map()
+            if any(len(v) > 1 for v in raw_vmap.values()):
+                raise NotImplementedError("Complex variables are not yet supported.")
+            var_id_map = {k: v[0] for k, v in raw_vmap.items()}
             param_id_map = {k: v[0] for k, v in chain.compose_param_id_map().items()}
 
         # In newer CVXPY PSD is converted to SvecPSD with fresh IDs

--- a/src/cvxpylayers/utils/parse_args.py
+++ b/src/cvxpylayers/utils/parse_args.py
@@ -4,12 +4,17 @@ from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 import cvxpy as cp
 import cvxpy.constraints
+import numpy as np
 import scipy.sparse
+from cvxpy.reductions.cvx_attr2constr import CvxAttr2Constr
 from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ParamConeProg
 from cvxpy.utilities import scopes
 
 import cvxpylayers.interfaces
 from cvxpylayers._quad_form_dpp import SUPPORTS_QUAD_OBJ
+
+# guard import for backward compatibility with older CVXPY versions without SvecPSD
+_SVEC_PSD = getattr(cvxpy.constraints, "SvecPSD", None)
 
 if TYPE_CHECKING:
     import torch
@@ -90,6 +95,10 @@ class LayersContext:
     gp_param_to_log_param: dict[cp.Parameter, cp.Parameter] | None = None
     # Pre-computed mask: which params need log() for GP (JIT-compatible)
     gp_log_mask: tuple[bool, ...] | None = None
+    # Pre-computed upper-triangle indices for symmetric/PSD/NSD parameters.
+    # Entry i is (row_indices, col_indices) if parameter i needs upper-tri
+    # extraction before building p_stack, or None if it doesn't.
+    param_triu_indices: tuple[tuple[tuple[int, ...], tuple[int, ...]] | None, ...] = ()
 
     def validate_params(self, values: list) -> tuple:
         if len(values) != len(self.parameters):
@@ -143,6 +152,28 @@ class LayersContext:
         return ()
 
 
+def _compose_constr_id_map(chain: Any, inverse_data: list) -> dict[int, int]:
+    """Compose constraint ID maps across all reduction steps.
+
+    Each reduction step may assign fresh IDs. This traces each original
+    constraint ID through every step's cons_id_map and returns {orig_id: final_id}.
+    """
+    result: dict[int, int] = {}
+    for reduction, inv in zip(chain.reductions, inverse_data):
+        step_map: dict[int, int] = {}
+        if isinstance(reduction, CvxAttr2Constr) and len(inv) == 3:
+            # CvxAttr2Constr stores (id2new_var, id2old_var, cons_id_map) or () when it was a no-op.
+            _, _, step_map = inv
+        elif hasattr(inv, "cons_id_map") and isinstance(inv.cons_id_map, dict):
+            step_map = inv.cons_id_map
+        if step_map:
+            result = {orig: step_map.get(cur, cur) for orig, cur in result.items()}
+            for orig_id, new_id in step_map.items():
+                if orig_id not in result:
+                    result[orig_id] = new_id
+    return result
+
+
 def _build_dual_var_map(problem: cp.Problem) -> dict[int, cp.Constraint]:
     """Build mapping from dual variable ID to parent constraint.
 
@@ -169,9 +200,13 @@ def _dual_var_offset(var: cp.Variable, constraint: cp.Constraint) -> int:
     raise ValueError(f"Variable {var} not found in constraint {constraint}")
 
 
-def _build_primal_recovery(var: cp.Variable, param_prob: ParamConeProg) -> VariableRecovery:
+def _build_primal_recovery(
+    var: cp.Variable,
+    param_prob: ParamConeProg,
+    var_id_map: dict[int, int],
+) -> VariableRecovery:
     """Build recovery info for a primal variable."""
-    start = param_prob.var_id_to_col[var.id]
+    start = param_prob.var_id_to_col[var_id_map.get(var.id, var.id)]
     is_sym = hasattr(var, "is_symmetric") and var.is_symmetric() and len(var.shape) >= 2
 
     if is_sym:
@@ -198,9 +233,10 @@ def _build_dual_recovery(
     var: cp.Variable,
     parent_con: cp.Constraint,
     constr_id_to_slice: dict[int, slice],
+    constr_id_map: dict[int, int],
 ) -> VariableRecovery:
     """Build recovery info for a dual variable."""
-    constr_slice = constr_id_to_slice[parent_con.id]
+    constr_slice = constr_id_to_slice[constr_id_map.get(parent_con.id, parent_con.id)]
     offset = _dual_var_offset(var, parent_con)
     dual_start = constr_slice.start + offset
 
@@ -226,7 +262,7 @@ def _build_constr_id_to_slice(param_prob: ParamConeProg) -> dict[int, slice]:
     """Build mapping from constraint ID to slice in dual solution vector.
 
     The dual solution vector is ordered by cone type:
-    Zero (equalities) -> NonNeg (inequalities) -> SOC -> ExpCone -> PSD -> PowCone3D
+    Zero (equalities) -> NonNeg (inequalities) -> SOC -> PSD/SvecPSD -> ExpCone -> PowCone3D
 
     Args:
         param_prob: CVXPY's parametrized cone program
@@ -238,14 +274,24 @@ def _build_constr_id_to_slice(param_prob: ParamConeProg) -> dict[int, slice]:
     cur_idx = 0
 
     # Process each cone type in canonical order
-    cone_types = [
-        cvxpy.constraints.Zero,
-        cvxpy.constraints.NonNeg,
-        cvxpy.constraints.SOC,
-        cvxpy.constraints.ExpCone,
-        cvxpy.constraints.PSD,
-        cvxpy.constraints.PowCone3D,
-    ]
+    if _SVEC_PSD is not None:
+        cone_types = [
+            cvxpy.constraints.Zero,
+            cvxpy.constraints.NonNeg,
+            cvxpy.constraints.SOC,
+            _SVEC_PSD,
+            cvxpy.constraints.ExpCone,
+            cvxpy.constraints.PowCone3D,
+        ]
+    else:
+        cone_types = [
+            cvxpy.constraints.Zero,
+            cvxpy.constraints.NonNeg,
+            cvxpy.constraints.SOC,
+            cvxpy.constraints.PSD,
+            cvxpy.constraints.ExpCone,
+            cvxpy.constraints.PowCone3D,
+        ]
 
     for cone_type in cone_types:
         for c in param_prob.constr_map.get(cone_type, []):
@@ -293,8 +339,16 @@ def _validate_problem(
         # Constraints: check WITHOUT scope (parametric quad_form P rejected).
         # Temporarily deactivate the scope so that quad_form(x, P) in
         # constraints is correctly flagged as non-DPP.
-        prev = scopes._quad_form_dpp_scope_active  # pyright: ignore[reportAttributeAccessIssue]
-        scopes._quad_form_dpp_scope_active = False  # pyright: ignore[reportAttributeAccessIssue]
+        # Newer CVXPY stores the flag in a thread-local while older versions use
+        # a plain module attribute.
+        if hasattr(scopes, "_thread_local"):
+            _scope_obj: Any = scopes._thread_local  # type: ignore[attr-defined]
+            _scope_attr = "quad_form_dpp_scope_active"
+        else:
+            _scope_obj = scopes
+            _scope_attr = "_quad_form_dpp_scope_active"
+        prev = getattr(_scope_obj, _scope_attr, False)
+        setattr(_scope_obj, _scope_attr, False)
         try:
             for c in problem.constraints:
                 if not c.is_dcp(dpp=True):  # type: ignore[call-arg]
@@ -303,7 +357,7 @@ def _validate_problem(
                         "is only supported in the objective, not in constraints."
                     )
         finally:
-            scopes._quad_form_dpp_scope_active = prev  # pyright: ignore[reportAttributeAccessIssue]
+            setattr(_scope_obj, _scope_attr, prev)
     else:
         if not problem.is_dcp(dpp=True):  # type: ignore[call-arg]
             raise ValueError("Problem must be DPP.")
@@ -330,8 +384,8 @@ def _validate_problem(
 def _build_user_order_mapping(
     parameters: list[cp.Parameter],
     param_prob: ParamConeProg,
-    gp: bool,
     gp_param_to_log_param: dict[cp.Parameter, cp.Parameter] | None,
+    param_id_map: dict[int, int],
 ) -> tuple[int, ...]:
     """Build mapping from user parameter order to column order.
 
@@ -342,14 +396,17 @@ def _build_user_order_mapping(
     Args:
         parameters: List of CVXPY parameters in user order
         param_prob: CVXPY's parametrized problem object
-        gp: Whether this is a geometric program
-        gp_param_to_log_param: Mapping from GP params to log-space DCP params
+        gp_param_to_log_param: Mapping from GP params to log-space DCP params, or None
+        param_id_map: Flat mapping from original param IDs to final canonical IDs
 
     Returns:
         Tuple mapping user parameter index to column order index (JIT-compatible)
     """
+    def _resolve(raw_id: int) -> int:
+        return param_id_map.get(raw_id, raw_id)
+
     # For GP problems, we need to use the log-space DCP parameter IDs
-    if gp and gp_param_to_log_param:
+    if gp_param_to_log_param:
         # Map user order index to column using log-space DCP parameters
         # Must sort by column position (same as non-GP path) so that
         # sequential slot indices match the canonical parameter order
@@ -359,7 +416,7 @@ def _build_user_order_mapping(
                 [
                     (
                         param_prob.param_id_to_col[
-                            gp_param_to_log_param[p].id if p in gp_param_to_log_param else p.id
+                            _resolve(gp_param_to_log_param[p].id if p in gp_param_to_log_param else p.id)
                         ],
                         i,
                     )
@@ -372,7 +429,7 @@ def _build_user_order_mapping(
         user_order_to_col = {
             i: col
             for col, i in sorted(
-                [(param_prob.param_id_to_col[p.id], i) for i, p in enumerate(parameters)],
+                [(param_prob.param_id_to_col[_resolve(p.id)], i) for i, p in enumerate(parameters)],
             )
         }
 
@@ -444,22 +501,37 @@ def parse_args(
             gp_param_to_log_param = dgp2dcp.canon_methods._parameters
 
             # Get problem data from the already-transformed DCP problem
-            data, _, _ = dcp_problem.get_problem_data(
+            data, chain, inverse_data = dcp_problem.get_problem_data(
                 solver=solver,
                 gp=False,
                 verbose=verbose,
                 canon_backend=canon_backend,
                 solver_opts=solver_args,
             )
+
+            # In newer CVXPY, Dgp2Dcp gives fresh IDs to log-space variables
+            _dcp_var_map = {k: v[0] for k, v in chain.compose_var_id_map().items()}
+            var_id_map: dict[int, int] = {
+                orig_id: _dcp_var_map.get(log_ids[0], log_ids[0])
+                for orig_id, log_ids in dgp2dcp.var_id_map.items()
+            }
+            param_id_map: dict[int, int] = {}  # GP params handled via gp_param_to_log_param
         else:
             # Standard DCP path
-            data, _, _ = problem.get_problem_data(
+            data, chain, inverse_data = problem.get_problem_data(
                 solver=solver,
                 gp=False,
                 verbose=verbose,
                 canon_backend=canon_backend,
                 solver_opts=solver_args,
             )
+
+            # In newer CVXPY, lowered variables and parameters receive fresh IDs
+            var_id_map = {k: v[0] for k, v in chain.compose_var_id_map().items()}
+            param_id_map = {k: v[0] for k, v in chain.compose_param_id_map().items()}
+
+        # In newer CVXPY PSD is converted to SvecPSD with fresh IDs
+        constr_id_map = _compose_constr_id_map(chain, inverse_data)
 
     param_prob = data[cp.settings.PARAM_PROB]  # type: ignore[attr-defined]
     cone_dims = data["dims"]
@@ -476,7 +548,7 @@ def parse_args(
 
     # Build parameter ordering mapping
     user_order_to_col_order = _build_user_order_mapping(
-        parameters, param_prob, gp, gp_param_to_log_param
+        parameters, param_prob, gp_param_to_log_param, param_id_map
     )
 
     q = getattr(param_prob, "q", getattr(param_prob, "c", None))
@@ -488,15 +560,33 @@ def parse_args(
     var_recover = []
     for v in variables:
         if v in primal_vars:
-            var_recover.append(_build_primal_recovery(v, param_prob))
+            var_recover.append(_build_primal_recovery(v, param_prob, var_id_map))
         else:
             parent_con = dual_var_to_constraint[v.id]
-            var_recover.append(_build_dual_recovery(v, parent_con, constr_id_to_slice))
+            var_recover.append(_build_dual_recovery(v, parent_con, constr_id_to_slice, constr_id_map))
 
     # Pre-compute GP log mask for JIT compatibility
     gp_log_mask = None
     if gp and gp_param_to_log_param:
         gp_log_mask = tuple(p in gp_param_to_log_param for p in parameters)
+
+    # Pre-compute upper-triangle indices for (symmetric/hermitian attributes) parameters
+    # that CVXPY lowered to their upper-tri vector form
+    triu_list: list[tuple[tuple[int, ...], tuple[int, ...]] | None] = []
+    for p in parameters:
+        if getattr(p, "_has_dim_reducing_attr", False) and p.id in param_id_map:
+            if p.attributes.get("symmetric") or p.attributes.get("hermitian"):
+                n = p.shape[-1]
+                rows, cols = np.triu_indices(n)
+                triu_list.append((tuple(rows.tolist()), tuple(cols.tolist())))
+            else:
+                raise NotImplementedError(
+                    f"Parameter '{p.name()}' has a dimension-reducing attribute "
+                    f"(diag, sparsity, or similar) that cvxpylayers does not yet handle"
+                )
+        else:
+            triu_list.append(None)
+    param_triu_indices = tuple(triu_list)
 
     return LayersContext(
         parameters,
@@ -511,4 +601,5 @@ def parse_args(
         gp=gp,
         gp_param_to_log_param=gp_param_to_log_param,
         gp_log_mask=gp_log_mask,
+        param_triu_indices=param_triu_indices,
     )

--- a/src/cvxpylayers/utils/parse_args.py
+++ b/src/cvxpylayers/utils/parse_args.py
@@ -281,6 +281,7 @@ def _validate_problem(
     parameters: list[cp.Parameter],
     gp: bool,
     dual_var_to_constraint: dict[int, cp.Constraint],
+    qp_solver: bool,
 ) -> None:
     """Validate that the problem is DPP-compliant and inputs are well-formed.
 
@@ -290,29 +291,24 @@ def _validate_problem(
         parameters: List of CVXPY parameters
         gp: Whether this is a geometric program (GP)
         dual_var_to_constraint: Mapping from dual variable ID to parent constraint
+        qp_solver: Whether the solver handles quadratic objectives directly.
+            When True, quad_form(x, P) with parametric P is allowed in the
+            objective but rejected in constraints.
 
     Raises:
         ValueError: If problem is not DPP-compliant or inputs are invalid
     """
-    # Check if problem follows disciplined parametrized programming (DPP) rules
     if gp:
-        if not problem.is_dgp(dpp=True):  # type: ignore[call-arg]
+        if not problem.is_dpp('dgp'):
             raise ValueError("Problem must be DPP for geometric programming.")
-    elif scopes.quad_form_dpp_scope_active():  # pyright: ignore[reportAttributeAccessIssue]
-        # quad_form_dpp_scope is active (QP-capable solver).
-        # Objective: check WITH scope (parametric quad_form P allowed)
-        if not problem.objective.is_dcp(dpp=True):  # type: ignore[call-arg]
-            raise ValueError("Problem must be DPP.")
-        # Constraints: check WITHOUT scope (parametric quad_form P rejected).
-        with scopes.suspend_quad_form_dpp_scope():
-            for c in problem.constraints:
-                if not c.is_dcp(dpp=True):  # type: ignore[call-arg]
-                    raise ValueError(
-                        "Problem must be DPP. Note: quad_form(x, P) with parametric P "
-                        "is only supported in the objective, not in constraints."
-                    )
+    elif qp_solver:
+        if not problem.is_dpp(quad_form_dpp='qp'):  # type: ignore[call-arg]
+            raise ValueError(
+                "Problem must be DPP. Note: quad_form(x, P) with parametric P "
+                "is only supported in the objective, not in constraints."
+            )
     else:
-        if not problem.is_dcp(dpp=True):  # type: ignore[call-arg]
+        if not problem.is_dpp():
             raise ValueError("Problem must be DPP.")
 
     # Validate parameters match problem definition
@@ -429,12 +425,13 @@ def parse_args(
 
     if solver is None:
         solver = "DIFFCP"
+        
+    qp_solver = solver in SUPPORTS_QUAD_OBJ
+    _validate_problem(problem, variables, parameters, gp, dual_var_to_constraint, qp_solver)
 
-    # For QP-capable solvers, enter quad_form_dpp_scope so that
-    # parametric quad_form(x, P) passes DPP validation and canonicalization.
-    with (scopes.quad_form_dpp_scope() if solver in SUPPORTS_QUAD_OBJ else contextlib.nullcontext()):
-        # Validate problem is DPP (disciplined parametrized programming)
-        _validate_problem(problem, variables, parameters, gp, dual_var_to_constraint)
+    # Enter quad_form_dpp_scope for QP-capable solvers so that get_problem_data
+    # caches and canonicalizes under the QP-aware key (parametric quad_form P allowed).
+    with (scopes.quad_form_dpp_scope() if qp_solver else contextlib.nullcontext()):
 
         # Handle GP problems using native CVXPY reduction (cvxpy >= 1.7.4)
         gp_param_to_log_param = None

--- a/tests/test_mpax.py
+++ b/tests/test_mpax.py
@@ -405,7 +405,7 @@ def test_soc_problem_rejected():
     x = cp.Variable(3)
     problem = cp.Problem(cp.Minimize(cp.norm(x, 2)), [x >= 0])
 
-    with pytest.raises(SolverError, match="could not be reduced to a QP"):
+    with pytest.raises(SolverError, match="cannot solve this problem"):
         CvxpyLayer(problem, [], [x], solver="MPAX")
 
 
@@ -415,7 +415,7 @@ def test_exponential_cone_rejected():
     x = cp.Variable()
     problem = cp.Problem(cp.Minimize(-cp.log(x)), [x >= 0.1])
 
-    with pytest.raises(SolverError, match="could not be reduced to a QP"):
+    with pytest.raises(SolverError, match="cannot solve this problem"):
         CvxpyLayer(problem, [], [x], solver="MPAX")
 
 
@@ -425,7 +425,7 @@ def test_sdp_rejected():
     X = cp.Variable((3, 3), PSD=True)
     problem = cp.Problem(cp.Minimize(cp.trace(X)))
 
-    with pytest.raises(SolverError, match="could not be reduced to a QP"):
+    with pytest.raises(SolverError, match="cannot solve this problem"):
         CvxpyLayer(problem, [], [X], solver="MPAX")
 
 


### PR DESCRIPTION
Recent changes in CVXPY appear to have broken CVXPYlayers. In particular, the new variable and parameter ID bookkeeping ([#3147](https://github.com/cvxpy/cvxpy/pull/3147) in CVXPY) for such leaves with dimension-reducing attributes needs to be adopted in CVXPYlayers.