### PR TITLE
Request sufficient accuracy in three gradient checks

### DIFF
--- a/tests/test_dual_variables.py
+++ b/tests/test_dual_variables.py
@@ -250,7 +250,7 @@ def test_dual_gradcheck_inequality():
 
     # Function that returns dual variable for gradcheck
     def f(c_t):
-        x_opt, ineq_dual = layer(c_t)
+        x_opt, ineq_dual = layer(c_t, solver_args={"eps": 1e-10})
         return ineq_dual
 
     c_t = torch.tensor([1.0, -1.0], requires_grad=True)
@@ -303,7 +303,7 @@ def test_dual_gradcheck_vector_equality():
     )
 
     def f(A_t, b_t):
-        x_opt, eq_dual = layer(A_t, b_t)
+        x_opt, eq_dual = layer(A_t, b_t, solver_args={"eps": 1e-10})
         return eq_dual.sum()
 
     torch.manual_seed(42)

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -245,7 +245,10 @@ def test_sdp():
     # Use a well-conditioned symmetric matrix
     C_t = torch.tensor([[2.0, 0.5, 0.1], [0.5, 3.0, 0.2], [0.1, 0.2, 1.5]], requires_grad=True)
 
-    torch.autograd.gradcheck(layer, (C_t,), atol=1e-4, rtol=1e-3)
+    torch.autograd.gradcheck(
+        lambda C: layer(C, solver_args={"eps": 1e-10}),
+        (C_t,), atol=1e-4, rtol=1e-3,
+    )
 
 
 def test_not_enough_parameters():


### PR DESCRIPTION
## Description
Three finite-difference gradient checks fail with SCS 3.3.1 at default solve accuracy: inequality duals, vector-equality duals, and the SDP example. Their finite-difference step is smaller than the solver error, so perturbations can produce a numerical Jacobian that disagrees with the analytical derivative.

Request `eps=1e-10` at those three call sites, following the existing gradient tests that already specify this tolerance. The gradient assertions and finite-difference settings are unchanged. This is six added lines and three removed lines across two test files; there are no dependency caps or production-code changes.

Found while investigating CVXPY CI in cvxpy/cvxpy#3513. CVXPY's extension workflow clones this repository, so its remaining three failures need this upstream change.

## Validation
- Reproduced all three failures locally with SCS 3.3.1 before the change; all three pass afterward.
- `pytest tests/test_dual_variables.py tests/test_torch.py`: 50 passed, 28 skipped (optional backends), against CVXPY master plus cvxpy/cvxpy#3513.
- Ruff passes on both changed files.
- Kept as a draft for upstream CI and review.
