### PR TITLE
Solve tightly in gradcheck tests rather than loosening atol (fixes #244)

### DIFF
--- a/tests/test_dual_variables.py
+++ b/tests/test_dual_variables.py
@@ -10,6 +10,14 @@ from cvxpylayers.torch import CvxpyLayer  # noqa: E402
 
 torch.set_default_dtype(torch.double)
 
+# ``gradcheck`` compares the analytic derivative against a finite difference with a step
+# of ~1e-6, so the forward solve has to be accurate to well below that or the difference
+# quotient is dominated by solver noise rather than by curvature. SCS's default tolerance
+# is not enough: it caps the accuracy of both the finite difference *and* the implicit
+# derivative at ~1e-4, which is the tolerance these tests assert. Ask for a tight solve
+# instead of loosening the assertions - see issue #244.
+GRADCHECK_SOLVER_ARGS = {"eps": 1e-10}
+
 
 def test_equality_constraint_dual():
     """Test returning dual variable for equality constraint."""
@@ -220,6 +228,7 @@ def test_dual_gradcheck_equality():
         prob,
         parameters=[c, b],
         variables=[x, eq_con.dual_variables[0]],
+        solver_args=GRADCHECK_SOLVER_ARGS,
     )
 
     # Function that returns dual variable for gradcheck
@@ -246,6 +255,7 @@ def test_dual_gradcheck_inequality():
         prob,
         parameters=[c],
         variables=[x, ineq_con.dual_variables[0]],
+        solver_args=GRADCHECK_SOLVER_ARGS,
     )
 
     # Function that returns dual variable for gradcheck
@@ -272,6 +282,7 @@ def test_dual_gradcheck_mixed():
         prob,
         parameters=[c, b],
         variables=[x, eq_con.dual_variables[0]],
+        solver_args=GRADCHECK_SOLVER_ARGS,
     )
 
     # Function that returns both primal and dual for gradcheck
@@ -300,6 +311,7 @@ def test_dual_gradcheck_vector_equality():
         prob,
         parameters=[A, b],
         variables=[x, eq_con.dual_variables[0]],
+        solver_args=GRADCHECK_SOLVER_ARGS,
     )
 
     def f(A_t, b_t):
@@ -357,6 +369,7 @@ def test_soc_gradcheck():
         prob,
         parameters=[c, t],
         variables=[x, soc_con.dual_variables[0]],
+        solver_args=GRADCHECK_SOLVER_ARGS,
     )
 
     def f(c_t, t_t):
@@ -446,6 +459,7 @@ def test_exp_cone_gradcheck():
             exp_con.dual_variables[1],
             exp_con.dual_variables[2],
         ],
+        solver_args=GRADCHECK_SOLVER_ARGS,
     )
 
     def f(t_t):
@@ -564,6 +578,7 @@ def test_psd_gradcheck():
         prob,
         parameters=[C],
         variables=[X, psd_con.dual_variables[0]],
+        solver_args=GRADCHECK_SOLVER_ARGS,
     )
 
     def f(C_t):
@@ -718,6 +733,7 @@ def test_gp_dual_gradcheck():
         parameters=[a, b],
         variables=[x, y, ineq_con.dual_variables[0]],
         gp=True,
+        solver_args=GRADCHECK_SOLVER_ARGS,
     )
 
     def f(a_t, b_t):
@@ -792,6 +808,7 @@ def test_soc_explicit_multi_dual_gradcheck():
         prob,
         parameters=[c, t_param],
         variables=[x, t, soc_con.dual_variables[0], soc_con.dual_variables[1]],
+        solver_args=GRADCHECK_SOLVER_ARGS,
     )
 
     def f(c_t, t_t):

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -15,6 +15,14 @@ from cvxpylayers.torch import CvxpyLayer  # noqa: E402
 
 torch.set_default_dtype(torch.double)
 
+# ``gradcheck`` compares the analytic derivative against a finite difference with a step
+# of ~1e-6, so the forward solve has to be accurate to well below that or the difference
+# quotient is dominated by solver noise rather than by curvature. SCS's default tolerance
+# is not enough: it caps the accuracy of both the finite difference *and* the implicit
+# derivative at ~1e-4, which is the tolerance these tests assert. Ask for a tight solve
+# instead of loosening the assertions - see issue #244.
+GRADCHECK_SOLVER_ARGS = {"eps": 1e-10}
+
 
 def set_seed(x: int) -> np.random.Generator:
     """Set the random seed for torch and return a numpy random generator.
@@ -77,7 +85,7 @@ def test_simple_batch_socp():
     constraints = [A @ x == b, cp.norm(x) <= 1]
     prob = cp.Problem(cp.Minimize(objective), constraints)
 
-    prob_tch = CvxpyLayer(prob, [P_sqrt, q, A, b], [x])
+    prob_tch = CvxpyLayer(prob, [P_sqrt, q, A, b], [x], solver_args=GRADCHECK_SOLVER_ARGS)
 
     P_sqrt_tch = torch.randn(batch_size, n, n, requires_grad=True)
     q_tch = torch.randn(batch_size, n, 1, requires_grad=True)
@@ -182,7 +190,7 @@ def test_logistic_regression():
     )
     prob = cp.Problem(cp.Minimize(-log_likelihood + lam * cp.sum_squares(a)))
 
-    fit_logreg = CvxpyLayer(prob, [X, lam], [a])
+    fit_logreg = CvxpyLayer(prob, [X, lam], [a], solver_args=GRADCHECK_SOLVER_ARGS)
 
     torch.autograd.gradcheck(fit_logreg, (X_th, lam_th), atol=1e-4)
 
@@ -206,7 +214,7 @@ def test_entropy_maximization():
     obj = cp.Maximize(cp.sum(cp.entr(x)) - 0.01 * cp.sum_squares(x))
     constraints = [A @ x == b, F @ x <= g]
     prob = cp.Problem(obj, constraints)
-    layer = CvxpyLayer(prob, [A, b, F, g], [x])
+    layer = CvxpyLayer(prob, [A, b, F, g], [x], solver_args=GRADCHECK_SOLVER_ARGS)
 
     A_th, b_th, F_th, g_th = map(
         lambda x: torch.from_numpy(x).requires_grad_(),
@@ -224,7 +232,7 @@ def test_lml():
     obj = -x @ y - cp.sum(cp.entr(y)) - cp.sum(cp.entr(1.0 - y))
     cons = [cp.sum(y) == k]
     prob = cp.Problem(cp.Minimize(obj), cons)
-    lml = CvxpyLayer(prob, [x], [y])
+    lml = CvxpyLayer(prob, [x], [y], solver_args=GRADCHECK_SOLVER_ARGS)
 
     x_th = torch.tensor([1.0, -1.0, -1.0, -1.0]).requires_grad_()
     torch.autograd.gradcheck(lml, (x_th,), atol=1e-3)
@@ -240,12 +248,16 @@ def test_sdp():
     trace_con = cp.trace(X) == 1
     prob = cp.Problem(cp.Minimize(cp.trace(C @ X)), [psd_con, trace_con])
 
-    layer = CvxpyLayer(prob, parameters=[C], variables=[X])
+    layer = CvxpyLayer(prob, parameters=[C], variables=[X], solver_args=GRADCHECK_SOLVER_ARGS)
 
     # Use a well-conditioned symmetric matrix
     C_t = torch.tensor([[2.0, 0.5, 0.1], [0.5, 3.0, 0.2], [0.1, 0.2, 1.5]], requires_grad=True)
 
-    torch.autograd.gradcheck(layer, (C_t,), atol=1e-4, rtol=1e-3)
+    # The optimum is the rank-one projector onto the smallest eigenvector of C, so most
+    # entries of dX/dC are near zero and are compared against ``atol`` alone. Even with a
+    # tight solve, the default 1e-6 step leaves those entries at the finite-difference
+    # floor (~1e-4); a larger step trades truncation error for noise and gives real margin.
+    torch.autograd.gradcheck(layer, (C_t,), eps=1e-4, atol=1e-4, rtol=1e-3)
 
 
 def test_not_enough_parameters():
@@ -419,7 +431,7 @@ def test_equality():
     x = cp.Variable(n)
     b = cp.Parameter(n)
     prob = cp.Problem(cp.Minimize(cp.sum_squares(x)), [A @ x == b])
-    layer = CvxpyLayer(prob, parameters=[b], variables=[x])
+    layer = CvxpyLayer(prob, parameters=[b], variables=[x], solver_args=GRADCHECK_SOLVER_ARGS)
 
     b_th = torch.randn(n).double().requires_grad_()
 
@@ -441,7 +453,13 @@ def test_basic_gp():
     problem = cp.Problem(cp.Minimize(objective_fn), constraints)
     problem.solve(cp.CLARABEL, gp=True)
 
-    layer = CvxpyLayer(problem, parameters=[a, b, c], variables=[x, y, z], gp=True)
+    layer = CvxpyLayer(
+        problem,
+        parameters=[a, b, c],
+        variables=[x, y, z],
+        gp=True,
+        solver_args=GRADCHECK_SOLVER_ARGS,
+    )
     a_th = torch.tensor([2.0]).requires_grad_()
     b_th = torch.tensor([1.0]).requires_grad_()
     c_th = torch.tensor([0.5]).requires_grad_()
@@ -476,7 +494,13 @@ def test_batched_gp():
     problem = cp.Problem(cp.Minimize(objective_fn), constraints)
 
     # Create layer
-    layer = CvxpyLayer(problem, parameters=[a, b, c], variables=[x, y, z], gp=True)
+    layer = CvxpyLayer(
+        problem,
+        parameters=[a, b, c],
+        variables=[x, y, z],
+        gp=True,
+        solver_args=GRADCHECK_SOLVER_ARGS,
+    )
 
     # Batched parameters - test with batch size 4 (double precision)
     # For scalar parameters, batching means 1D tensors
@@ -536,7 +560,13 @@ def test_gp_without_param_values():
     problem = cp.Problem(cp.Minimize(objective_fn), constraints)
 
     # This should work WITHOUT needing to set a.value, b.value, c.value
-    layer = CvxpyLayer(problem, parameters=[a, b, c], variables=[x, y, z], gp=True)
+    layer = CvxpyLayer(
+        problem,
+        parameters=[a, b, c],
+        variables=[x, y, z],
+        gp=True,
+        solver_args=GRADCHECK_SOLVER_ARGS,
+    )
 
     # Now use the layer with actual parameter values
     a_th = torch.tensor([2.0], dtype=torch.float64, requires_grad=True)
@@ -586,8 +616,20 @@ def test_gp_reversed_parameter_order():
     problem = cp.Problem(cp.Minimize(objective_fn), constraints)
 
     # Create layers with parameters in different orders
-    layer_abc = CvxpyLayer(problem, parameters=[a, b, c], variables=[x, y, z], gp=True)
-    layer_cba = CvxpyLayer(problem, parameters=[c, b, a], variables=[x, y, z], gp=True)
+    layer_abc = CvxpyLayer(
+        problem,
+        parameters=[a, b, c],
+        variables=[x, y, z],
+        gp=True,
+        solver_args=GRADCHECK_SOLVER_ARGS,
+    )
+    layer_cba = CvxpyLayer(
+        problem,
+        parameters=[c, b, a],
+        variables=[x, y, z],
+        gp=True,
+        solver_args=GRADCHECK_SOLVER_ARGS,
+    )
 
     a_th = torch.tensor([2.0], dtype=torch.float64, requires_grad=True)
     b_th = torch.tensor([1.0], dtype=torch.float64, requires_grad=True)


### PR DESCRIPTION
Fixes #244.

## The variable is the tolerance, not the SCS version

`scs >= 3.3.0` broke three gradcheck tests. It turns out neither SCS nor the implicit derivative is wrong — **both sides of the gradcheck comparison were only accurate to ~1e-4, which is the `atol` being asserted.**

Measured against the closed-form Jacobian of `test_dual_gradcheck_vector_equality`:

| solver tolerance | analytic gradient error |
| --- | --- |
| SCS default | 1.25e-02 |
| `eps=1e-10` | 7.0e-10 |

Same story for `test_sdp`: the layer's analytic Jacobian is off by 3.05e-04 at default tolerance and 2.4e-08 at `eps=1e-8`. So cvxpylayers' derivative machinery is correct, and its accuracy is capped by the forward solve.

The finite difference is worse. At default tolerance its error is pinned at ~3.4e-04 for **every** step size from 1e-6 to 1e-3 — that is solver noise, not curvature — and only starts scaling with `h` once the solve is tight:

| solver tolerance | h=1e-6 | h=1e-5 | h=1e-4 |
| --- | --- | --- | --- |
| default | 3.35e-04 | 3.50e-04 | 3.50e-04 |
| `eps=1e-10` | 8.16e-05 | 8.24e-06 | 7.26e-07 |

3.3.x broke nothing. It stopped over-delivering on the requested tolerance, so the two noise realizations stopped cancelling. The 1.4x margin on 3.2.11 reported in the issue was the noise floor rather than a margin.

## The fix

Of the three directions in #244 this is (3): fix the accuracy, don't hide the symptom. **No assertion is loosened and no `scs` bound is added.**

- `GRADCHECK_SOLVER_ARGS = {"eps": 1e-10}`, passed at layer construction in all 14 diffcp-backed gradcheck tests — not just the three that failed, since every one of them had the same latent exposure.
- `test_sdp` additionally takes `eps=1e-4` for the finite-difference step. Its optimum is the rank-one projector onto the smallest eigenvector of `C`, so most entries of `dX/dC` are near zero and are compared against `atol` alone; a tight solve alone leaves those sitting exactly at the finite-difference floor.
- The `solver="MOREAU"` gradcheck tests are left alone: `eps` is a diffcp/SCS key and those tests are unaffected.

## Margins

From a harness that shrinks `atol` on each gradcheck test until it fails:

| | before | after, 3.3.1 | after, 3.2.11 |
| --- | --- | --- | --- |
| `test_sdp` | fails | 1000x | 1000x |
| `test_dual_gradcheck_inequality` | fails | 10,000x | 100,000x |
| `test_dual_gradcheck_vector_equality` | fails | >10⁶x | >10⁶x |
| tightest of all 18 gradcheck tests | ~1x | 1000x | 1000x |

## Verification

- **87 passed / 40 skipped on both `scs==3.3.1` and `scs==3.2.11`** (baseline: 3 failed / 84 passed on 3.3.1)
- `ruff@0.12.7 check` clean on both touched files; `ruff format --diff` is byte-identical before and after, so the change is format-neutral (`tests/test_torch.py` is CRLF and already fails `format --check` on master, along with two other test files — left as-is rather than dragging in ~2700 lines of reformatting)

This should turn `test_cvxpylayers` in cvxpy's `extensions.yml` green again.

## Upstream

Diagnosis confirmed independently by SCS upstream in cvxgrp/scs#464, which closed with exactly this prescription: *"gradcheck tests should pass tight solver tolerances via `solver_args`, and the SDP check needs either a larger finite-difference step or a comparison against a closed-form derivative."* cvxgrp/scs#463 investigated 3.3.0's b-dependent equilibration as the mechanism and ruled it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
